### PR TITLE
(PDOC-6) Allow for different puppet gem versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,14 @@
 source 'https://rubygems.org'
 
 gem 'yard'
-gem 'puppet', '~> 3.6.2'
 gem 'rgen'
 gem 'redcarpet'
+
+if puppetversion = ENV['PUPPET_VERSION']
+  gem 'puppet', puppetversion
+else
+  gem 'puppet', '~> 3.6.2'
+end
 
 group :test do
   gem 'rspec'


### PR DESCRIPTION
In order to make the Gemfile compatible with the puppet strings
Jenkins job (which tests against multiple versions of puppet), update
the Gemfile to allow for for the Jenkins job to specify which version
of puppet it is testing against.
