### PR TITLE
(PDOC-7) Add .travis file for Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: ruby
+bundler_args: --without development
+script: "bundle exec rake spec SPEC_OPTS='--color --format documentation'"
+notifications:
+  email: false
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - ruby-head
+env:
+  - PUPPET_VERSION=3.6.2
+  - PUPPET_VERSION=3.7.1
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: ruby-head


### PR DESCRIPTION
Since we want Travis CI to run spec tests for pull requests opened
for puppet strings, add a .travis.yaml file so that Travis CI can
run spec tests.
