### PR TITLE
(PDOC-14) Fix strings to work with future parser

### DIFF
--- a/lib/puppetx/puppetlabs/strings.rb
+++ b/lib/puppetx/puppetlabs/strings.rb
@@ -1,6 +1,6 @@
 require 'puppet'
-require 'puppetx'
 require 'puppet/pops'
+require 'puppetx'
 require 'puppet/util/docs'
 require 'yard'
 


### PR DESCRIPTION
Prior to this commit, two require statements were in the wrong
order, causing strings to fail when running against anything that
required the future parser.

Now, those requires have been flipped and strings can run with
`--parser future` successfully.
