### PR TITLE
(PDOC-63) Fix specs for Puppet versions less than 4.1.

### DIFF
--- a/spec/fixtures/unit/json/output_without_puppet_function.json
+++ b/spec/fixtures/unit/json/output_without_puppet_function.json
@@ -176,53 +176,6 @@
   ],
   "puppet_functions": [
     {
-      "name": "func",
-      "file": "(stdin)",
-      "line": 6,
-      "type": "puppet",
-      "signature": "func(Integer $param1, Any $param2, String $param3 = hi)",
-      "docstring": {
-        "text": "A simple function.",
-        "tags": [
-          {
-            "tag_name": "param",
-            "text": "First param.",
-            "types": [
-              "Integer"
-            ],
-            "name": "param1"
-          },
-          {
-            "tag_name": "param",
-            "text": "Second param.",
-            "types": [
-              "Any"
-            ],
-            "name": "param2"
-          },
-          {
-            "tag_name": "param",
-            "text": "Third param.",
-            "types": [
-              "String"
-            ],
-            "name": "param3"
-          },
-          {
-            "tag_name": "return",
-            "text": "Returns nothing.",
-            "types": [
-              "Undef"
-            ]
-          }
-        ]
-      },
-      "defaults": {
-        "param3": "hi"
-      },
-      "source": "function func(Integer $param1, $param2, String $param3 = hi) {\n}"
-    },
-    {
       "name": "func3x",
       "file": "(stdin)",
       "line": 1,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,14 @@
 require 'mocha'
 require 'rspec'
+require 'puppet/version'
 require 'puppet-strings'
 require 'puppet-strings/yard'
 
 # Explicitly set up YARD once
 PuppetStrings::Yard.setup!
+
+# Enable testing of Puppet functions if running against 4.1+
+TEST_PUPPET_FUNCTIONS = Gem::Dependency.new('', '>= 4.1.0').match?('', Puppet::PUPPETVERSION)
 
 RSpec.configure do |config|
   config.mock_with :mocha

--- a/spec/unit/puppet-strings/json_spec.rb
+++ b/spec/unit/puppet-strings/json_spec.rb
@@ -19,7 +19,10 @@ class klass(Integer $param1, $param2, String $param3 = hi) inherits foo::bar {
 # @param param3 Third param.
 define dt(Integer $param1, $param2, String $param3 = hi) {
 }
+SOURCE
 
+    # Only include Puppet functions for 4.1+
+    YARD::Parser::SourceParser.parse_string(<<-SOURCE, :puppet) if TEST_PUPPET_FUNCTIONS
 # A simple function.
 # @param param1 First param.
 # @param param2 Second param.
@@ -112,7 +115,8 @@ end
 SOURCE
   end
 
-  let(:baseline_path) { File.join(File.dirname(__FILE__), '../../fixtures/unit/json/output.json') }
+  let(:filename) { TEST_PUPPET_FUNCTIONS ? 'output.json' : 'output_without_puppet_function.json' }
+  let(:baseline_path) { File.join(File.dirname(__FILE__), "../../fixtures/unit/json/#{filename}") }
   let(:baseline) { File.read(baseline_path) }
 
   describe 'rendering JSON to a file' do

--- a/spec/unit/puppet-strings/yard/handlers/puppet/function_handler_spec.rb
+++ b/spec/unit/puppet-strings/yard/handlers/puppet/function_handler_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 require 'puppet-strings/yard'
 
-describe PuppetStrings::Yard::Handlers::Puppet::FunctionHandler do
+# Limit this spec to Puppet 4.1+ (when functions in Puppet were implemented)
+describe PuppetStrings::Yard::Handlers::Puppet::FunctionHandler, if: TEST_PUPPET_FUNCTIONS do
   subject {
     YARD::Parser::SourceParser.parse_string(source, :puppet)
     YARD::Registry.all(:puppet_function)

--- a/spec/unit/puppet-strings/yard/parsers/puppet/parser_spec.rb
+++ b/spec/unit/puppet-strings/yard/parsers/puppet/parser_spec.rb
@@ -133,7 +133,7 @@ SOURCE
     end
   end
 
-  describe 'parsing puppet functions' do
+  describe 'parsing puppet functions', if: TEST_PUPPET_FUNCTIONS do
     let(:source) { <<SOURCE
 notice hello
 # A simple foo function.


### PR DESCRIPTION
The specs test functions written in the Puppet language in a few places, but
this feature is only supported in Puppet 4.1+.  This commit prevents these
specs from running if targeting older versions of Puppet.