### PR TITLE
(PDOC-80) Remove runtime dependency on puppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ In order to run strings you need to have the following software installed:
   * Puppet 3.7 or newer
   * The `yard` Ruby gem
 
+Note that a few extra steps are necessary to install puppet-strings with Puppet Enterprise 3.8.
+
 Installing the YARD Gem
 -----------------------
 
@@ -45,6 +47,17 @@ $ puppet resource package yard provider=puppet_gem
 For Puppet 3.x:
 ```
 $ puppet resource package yard provider=gem
+```
+
+For Puppet Enterprise 3.8:
+```
+GEM_HOME=/opt/puppet/lib/ruby/gems/1.9.1 puppet resource package yard provider=gem
+```
+
+Installing the redcarpet Gem (Puppet Enterprise 3.8 only)
+-------------------------
+```
+GEM_HOME=/opt/puppet/lib/ruby/gems/1.9.1 puppet resource package redcarpet provider=gem
 ```
 
 Installing Puppet Strings
@@ -62,6 +75,11 @@ $ puppet resource package puppet-strings provider=puppet_gem
 For Puppet 3.x:
 ```
 $ puppet resource package puppet-strings provider=gem
+```
+
+For Puppet Enterprise 3.8:
+```
+GEM_HOME=/opt/puppet/lib/ruby/gems/1.9.1 puppet resource package puppet-strings provider=gem
 ```
 
 Running Puppet Strings

--- a/puppet-strings.gemspec
+++ b/puppet-strings.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   ]
   s.files = `git ls-files`.split("\n") - Dir['.*', '*.gemspec']
 
-  s.add_runtime_dependency 'puppet', '>= 3.7.0'
   s.add_runtime_dependency 'yard', '~> 0.9.5'
+  s.requirements << 'puppet, >= 3.7.0'
 end


### PR DESCRIPTION
The runtime dependency on puppet presents problems when
puppet is not installed on the system as a gem, as is the
case in PE installations. Because the dependency will only be
satisfied by a gem, strings currently cannot be installed in
PE 3.8. This had to be worked around in newer PE versions with
a fake gemspec file.

Another issue is that installing strings with an older
version of puppet will force an upgrade to the newest version of
puppet via the gem.

This commit replaces the runtime dependency on puppet with a
requirement which will be present on the gem homepage on
rubygems.org. Requirements are meant to list external requirements
needed for the gem to work, which is correct for puppet as it can be
present via a different type of package.