### PR TITLE
(maint) Pin beaker version to < 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
 end
 
 group :acceptance do
-  gem 'beaker'
+  gem 'beaker', '< 3.0'
   gem 'beaker-rspec'
   gem 'beaker-hostgenerator'
 end


### PR DESCRIPTION
Beaker 3.0 was recently released, and requires ruby > 2.0.
Since strings needs to support 1.9.3 in CI, we need to pin
beaker to < 3.0.