### PR TITLE
(PDOC-122) Properly parse `newfunction` calls with newlines

### DIFF
--- a/lib/puppet-strings/yard/handlers/ruby/function_handler.rb
+++ b/lib/puppet-strings/yard/handlers/ruby/function_handler.rb
@@ -23,12 +23,15 @@ class PuppetStrings::Yard::Handlers::Ruby::FunctionHandler < PuppetStrings::Yard
 
   process do
     # Only accept calls to Puppet::Functions (4.x) or Puppet::Parser::Functions (3.x)
+    # When `newfunction` is separated from the Puppet::Parser::Functions module name by a
+    # newline, YARD ignores the namespace and uses `newfunction` as the source of the
+    # first statement.
     return unless statement.count > 1
     module_name = statement[0].source
-    return unless module_name == 'Puppet::Functions' || module_name == 'Puppet::Parser::Functions'
+    return unless module_name == 'Puppet::Functions' || module_name == 'Puppet::Parser::Functions' || module_name == 'newfunction'
 
     # Create and register the function object
-    is_3x = module_name == 'Puppet::Parser::Functions'
+    is_3x = module_name == 'Puppet::Parser::Functions' || module_name == 'newfunction'
     object = PuppetStrings::Yard::CodeObjects::Function.new(
       get_name,
       is_3x ? PuppetStrings::Yard::CodeObjects::Function::RUBY_3X : PuppetStrings::Yard::CodeObjects::Function::RUBY_4X


### PR DESCRIPTION
When `newfunction` is separated from the Puppet::Parser::Functions module name by a
newline, YARD ignores the namespace and uses `newfunction` as the source of the
first statement.

Prior to this commit, strings didn't recognize this case, and 3.x functions written
in this way were not parsed as functions. This commit updates the ruby function handler
to identify and properly parse 3.x functions that include a newline between the
Puppet::Parser::Function namespace and the newfunction method call.