### PR TITLE
(PDOC-95) Properly group and display multiple provider `defaultfor`s

### DIFF
--- a/JSON.md
+++ b/JSON.md
@@ -3,7 +3,7 @@ Puppet Strings JSON Data
 
 Puppet Strings has two flags to the `generate` action that can be used to emit JSON data:
 
-* `--emit-json <file>`: Emits the JSON data to the given file. 
+* `--emit-json <file>`: Emits the JSON data to the given file.
 * `--emit-json-stdout`: Emits the JSON data to STDOUT.
 
 Document Schema
@@ -100,13 +100,13 @@ Each entry in the `providers` list is an object with the following attributes:
 | Attribute Key | Description                                          |
 | ------------- | ---------------------------------------------------- |
 | name          | The name of the provider.                            |
-| type_name     | The name of the resource type of the provider.       | 
+| type_name     | The name of the resource type of the provider.       |
 | file          | The file defining the provider.                      |
 | line          | The line where the provider is defined.              |
 | docstring     | The *DocString* object for the provider (see below). |
 | confines      | The string map of confines for the provider.         |
 | features      | The list of features implemented by the provider.    |
-| defaults      | The string map of "default for" for the provider.    |
+| defaults      | The list of lists of "default for" for the provider. |
 | commands      | The string map of commands for the provider.         |
 
 Puppet Functions
@@ -327,9 +327,24 @@ An example JSON document describing a Puppet class, defined type, resource type,
         "implements_some_feature",
         "some_other_feature"
       ],
-      "defaults": {
-        "kernel": "Linux"
-      },
+      "defaults": [
+        [
+          [
+            "kernel",
+            "Linux"
+          ]
+        ],
+        [
+          [
+            "osfamily",
+            "RedHat",
+          ],
+          [
+            "operatingsystemmajrelease",
+            "7"
+          ]
+        ]
+      ],
       "commands": {
         "foo": "/usr/bin/foo"
       }
@@ -508,4 +523,3 @@ An example JSON document describing a Puppet class, defined type, resource type,
   ]
 }
 ```
-

--- a/lib/puppet-strings/yard/code_objects/provider.rb
+++ b/lib/puppet-strings/yard/code_objects/provider.rb
@@ -56,13 +56,12 @@ class PuppetStrings::Yard::CodeObjects::Provider < PuppetStrings::Yard::CodeObje
   end
 
   # Adds a default to the provider.
-  # @param [String] key The default's key.
-  # @param [String] value The default's value.
+  # @param [Array] constraints List of related key-pair values for the default.
   # @return [void]
-  def add_default(key, value)
-    return unless key && value
-    @defaults ||= {}
-    @defaults[key] = value
+  def add_default(constraints)
+    return unless constraints
+    @defaults ||= []
+    @defaults << constraints
   end
 
   # Adds a command to the provider.

--- a/lib/puppet-strings/yard/handlers/ruby/provider_handler.rb
+++ b/lib/puppet-strings/yard/handlers/ruby/provider_handler.rb
@@ -96,9 +96,14 @@ class PuppetStrings::Yard::Handlers::Ruby::ProviderHandler < PuppetStrings::Yard
       elsif method_name == 'defaultfor'
         # Add a default to the object
         next unless parameters.count >= 1
-        parameters[0].each do |kvp|
-          next unless kvp.count == 2
-          object.add_default(node_as_string(kvp[0]) || kvp[0].source, node_as_string(kvp[1]) || kvp[1].source)
+        # Some defaultfor statements contain multiple constraints.
+        parameters.each do |kvps|
+          next unless kvps.count >= 1
+          defaultfor = []
+          kvps.each do |kvp|
+            defaultfor << [node_as_string(kvp[0]) || kvp[0].source, node_as_string(kvp[1]) || kvp[1].source]
+          end
+          object.add_default(defaultfor)
         end
       elsif method_name == 'commands'
         # Add the commands to the object

--- a/lib/puppet-strings/yard/templates/default/puppet_provider/html/collection.erb
+++ b/lib/puppet-strings/yard/templates/default/puppet_provider/html/collection.erb
@@ -2,8 +2,15 @@
 <div class="tags">
   <p class="tag_title"><%= @title %></p>
   <ul>
-  <% @collection.each do |key, value| %>
-    <li><tt><%= key %> &mdash; <%= value %></tt></li>
+
+  <% if @collection.is_a?(Hash) %>
+    <% @collection.each do |key, value| %>
+      <li><tt><%= key %> &mdash; <%= value %></tt></li>
+    <% end %>
+  <% elsif @collection.is_a?(Array) %>
+    <% @collection.each do |kvps| %>
+      <li><tt><%=  kvps.map{|k,v| "#{k} &mdash; #{v}"}.join(', ') %></tt></li>
+    <% end %>
   <% end %>
   </ul>
 </div>

--- a/spec/fixtures/unit/json/output.json
+++ b/spec/fixtures/unit/json/output.json
@@ -84,7 +84,7 @@
     {
       "name": "database",
       "file": "(stdin)",
-      "line": 43,
+      "line": 44,
       "docstring": {
         "text": "An example database server resource type."
       },
@@ -166,9 +166,24 @@
         "implements_some_feature",
         "some_other_feature"
       ],
-      "defaults": {
-        "kernel": "Linux"
-      },
+      "defaults": [
+        [
+          [
+            "kernel",
+            "Linux"
+          ]
+        ],
+        [
+          [
+            "osfamily",
+            "RedHat"
+          ],
+          [
+            "operatingsystemmajrelease",
+            "7"
+          ]
+        ]
+      ],
       "commands": {
         "foo": "/usr/bin/foo"
       }

--- a/spec/fixtures/unit/json/output_without_puppet_function.json
+++ b/spec/fixtures/unit/json/output_without_puppet_function.json
@@ -166,9 +166,24 @@
         "implements_some_feature",
         "some_other_feature"
       ],
-      "defaults": {
-        "kernel": "Linux"
-      },
+      "defaults": [
+        [
+          [
+            "kernel",
+            "Linux"
+          ]
+        ],
+        [
+          [
+            "osfamily",
+            "RedHat"
+          ],
+          [
+            "operatingsystemmajrelease",
+            "7"
+          ]
+        ]
+      ],
       "commands": {
         "foo": "/usr/bin/foo"
       }

--- a/spec/unit/puppet-strings/json_spec.rb
+++ b/spec/unit/puppet-strings/json_spec.rb
@@ -69,7 +69,8 @@ Puppet::Type.type(:database).provide :linux do
   desc 'An example provider on Linux.'
   confine kernel: 'Linux'
   confine osfamily: 'RedHat'
-  defaultfor kernel: 'Linux'
+  defaultfor :kernel => 'Linux'
+  defaultfor :osfamily => 'RedHat', :operatingsystemmajrelease => '7'
   has_feature :implements_some_feature
   has_feature :some_other_feature
   commands foo: /usr/bin/foo

--- a/spec/unit/puppet-strings/yard/handlers/ruby/provider_handler_spec.rb
+++ b/spec/unit/puppet-strings/yard/handlers/ruby/provider_handler_spec.rb
@@ -61,7 +61,8 @@ Puppet::Type.type(:custom).provide :linux do
   desc 'An example provider on Linux.'
   confine kernel: 'Linux'
   confine osfamily: 'RedHat'
-  defaultfor kernel: 'Linux'
+  defaultfor :kernel => 'Linux'
+  defaultfor :osfamily => 'RedHat', :operatingsystemmajrelease => '7'
   has_feature :implements_some_feature
   has_feature :some_other_feature
   commands foo: /usr/bin/foo
@@ -82,7 +83,7 @@ SOURCE
       expect(tags.size).to eq(1)
       expect(tags[0].text).to eq('public')
       expect(object.confines).to eq({ 'kernel' => 'Linux', 'osfamily' => 'RedHat'})
-      expect(object.defaults).to eq({ 'kernel' => 'Linux'})
+      expect(object.defaults).to eq([[["kernel", "Linux"]], [["osfamily", "RedHat"], ["operatingsystemmajrelease", "7"]]])
       expect(object.features).to eq(['implements_some_feature', 'some_other_feature'])
       expect(object.commands).to eq({'foo' => '/usr/bin/foo'})
     end


### PR DESCRIPTION
Prior to this commit, strings did not properly handle providers
which had multiple related `defaultfor`s. In code, these are written
as comma-separated constraints. This commit updates strings' puppet
provider handler, as well as the template which generates HTML for
`defaultfor` statements.

Note that it was necessary to make a breaking change to the JSON
schema to accomodate multiple AND'ed defaults. Previously, provider
defaults were contained in a single key-value map. Now, they are
contained in an array of key-value maps, which allows multiple
constraints to be associated with each other.