### PR TITLE
(PDOC-120) Update gh_pages task to allow publishing of _index.html

### DIFF
--- a/lib/puppet-strings/tasks/gh_pages.rb
+++ b/lib/puppet-strings/tasks/gh_pages.rb
@@ -24,6 +24,15 @@ namespace :strings do
       end
     end
 
+    desc 'Add Jekyll _config.yml file to allow publishing of _index.html.'
+    task :configure do
+      unless File.exist?(File.join('doc', '_config.yml'))
+        Dir.chdir('doc') do
+          File.open('_config.yml', 'w+') {|f| f.write("include: _index.html") }
+        end
+      end
+    end
+
     desc 'Push new docs to GitHub.'
     task :push do
       Dir.chdir('doc') do
@@ -37,6 +46,7 @@ namespace :strings do
     task :update => [
       :checkout,
       :'strings:generate',
+      :configure,
       :push,
     ]
   end


### PR DESCRIPTION
Previously, due to Jekyll's default rule of not allowing files beginning
with an '_' to be published, the gh_pages rake task led to broken links.
This commit adds a step to the task which adds a _config.yml file to the
`doc` directory of the gh-pages branch which explicitly allows the file
to be published.