### PR TITLE
(PDOC-129) Include tags in overload objects when serialized as JSON

### DIFF
--- a/lib/puppet-strings/yard/tags/overload_tag.rb
+++ b/lib/puppet-strings/yard/tags/overload_tag.rb
@@ -99,7 +99,7 @@ class PuppetStrings::Yard::Tags::OverloadTag < YARD::Tags::Tag
     hash[:tag_name] = tag_name
     hash[:text] = text if text
     hash[:signature] = signature
-    hash[:docstring] = PuppetStrings::Json.docstring_to_hash(docstring) if !docstring.empty?
+    hash[:docstring] = PuppetStrings::Json.docstring_to_hash(docstring) if !docstring.blank?
     defaults = Hash[*parameters.select{ |p| !p[1].nil? }.flatten]
     hash[:defaults] = defaults unless defaults.empty?
     hash[:types] = types if types

--- a/spec/fixtures/unit/json/output.json
+++ b/spec/fixtures/unit/json/output.json
@@ -84,7 +84,7 @@
     {
       "name": "database",
       "file": "(stdin)",
-      "line": 46,
+      "line": 45,
       "docstring": {
         "text": "An example database server resource type."
       },
@@ -154,7 +154,7 @@
       "name": "linux",
       "type_name": "database",
       "file": "(stdin)",
-      "line": 35,
+      "line": 34,
       "docstring": {
         "text": "An example provider on Linux."
       },
@@ -326,7 +326,7 @@
             "tag_name": "overload",
             "signature": "func4x(Boolean $param, Callable &$block)",
             "docstring": {
-              "text": "The second overload.",
+              "text": "",
               "tags": [
                 {
                   "tag_name": "param",
@@ -357,7 +357,7 @@
           }
         ]
       },
-      "source": "Puppet::Functions.create_function(:func4x) do\n  # The first overload.\n  # @param param1 The first parameter.\n  # @param param2 The second parameter.\n  # @param param3 The third parameter.\n  # @return Returns nothing.\n  dispatch :foo do\n    param          'Integer',       :param1\n    param          'Any',           :param2\n    optional_param 'Array[String]', :param3\n    return_type 'Undef'\n  end\n\n  # The second overload.\n  # @param param The first parameter.\n  # @param block The block parameter.\n  # @return Returns a string.\n  dispatch :other do\n    param 'Boolean', :param\n    block_param\n    return_type 'String'\n  end\nend"
+      "source": "Puppet::Functions.create_function(:func4x) do\n  # The first overload.\n  # @param param1 The first parameter.\n  # @param param2 The second parameter.\n  # @param param3 The third parameter.\n  # @return Returns nothing.\n  dispatch :foo do\n    param          'Integer',       :param1\n    param          'Any',           :param2\n    optional_param 'Array[String]', :param3\n    return_type 'Undef'\n  end\n\n  # @param param The first parameter.\n  # @param block The block parameter.\n  # @return Returns a string.\n  dispatch :other do\n    param 'Boolean', :param\n    block_param\n    return_type 'String'\n  end\nend"
     }
   ]
 }

--- a/spec/fixtures/unit/json/output_without_puppet_function.json
+++ b/spec/fixtures/unit/json/output_without_puppet_function.json
@@ -84,7 +84,7 @@
     {
       "name": "database",
       "file": "(stdin)",
-      "line": 46,
+      "line": 45,
       "docstring": {
         "text": "An example database server resource type."
       },
@@ -154,7 +154,7 @@
       "name": "linux",
       "type_name": "database",
       "file": "(stdin)",
-      "line": 35,
+      "line": 34,
       "docstring": {
         "text": "An example provider on Linux."
       },
@@ -279,7 +279,7 @@
             "tag_name": "overload",
             "signature": "func4x(Boolean $param, Callable &$block)",
             "docstring": {
-              "text": "The second overload.",
+              "text": "",
               "tags": [
                 {
                   "tag_name": "param",
@@ -310,7 +310,7 @@
           }
         ]
       },
-      "source": "Puppet::Functions.create_function(:func4x) do\n  # The first overload.\n  # @param param1 The first parameter.\n  # @param param2 The second parameter.\n  # @param param3 The third parameter.\n  # @return Returns nothing.\n  dispatch :foo do\n    param          'Integer',       :param1\n    param          'Any',           :param2\n    optional_param 'Array[String]', :param3\n    return_type 'Undef'\n  end\n\n  # The second overload.\n  # @param param The first parameter.\n  # @param block The block parameter.\n  # @return Returns a string.\n  dispatch :other do\n    param 'Boolean', :param\n    block_param\n    return_type 'String'\n  end\nend"
+      "source": "Puppet::Functions.create_function(:func4x) do\n  # The first overload.\n  # @param param1 The first parameter.\n  # @param param2 The second parameter.\n  # @param param3 The third parameter.\n  # @return Returns nothing.\n  dispatch :foo do\n    param          'Integer',       :param1\n    param          'Any',           :param2\n    optional_param 'Array[String]', :param3\n    return_type 'Undef'\n  end\n\n  # @param param The first parameter.\n  # @param block The block parameter.\n  # @return Returns a string.\n  dispatch :other do\n    param 'Boolean', :param\n    block_param\n    return_type 'String'\n  end\nend"
     }
   ]
 }

--- a/spec/unit/puppet-strings/json_spec.rb
+++ b/spec/unit/puppet-strings/json_spec.rb
@@ -56,7 +56,6 @@ Puppet::Functions.create_function(:func4x) do
     return_type 'Undef'
   end
 
-  # The second overload.
   # @param param The first parameter.
   # @param block The block parameter.
   # @return Returns a string.


### PR DESCRIPTION
Previously, overload objects were not displaying their tags when
they had no docstring text. This was due to an issue in the overload
`to_hash` method, which prevented the tags from being serialized when
the dispatch had no top-level text. This commit updates that logic
so that the tags will always be included in the hash if they exist.