### PR TITLE
(maint) Pin YARD to 0.9.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem 'rgen'
 gem 'redcarpet'
-gem 'yard', '~> 0.9.5'
+gem 'yard', '0.9.5'
 
 if ENV['PUPPET_GEM_VERSION']
   gem 'puppet', ENV['PUPPET_GEM_VERSION'], :require => false


### PR DESCRIPTION
There is currently a parsing bug in YAD 0.9.6 and above
which causes errors on certain strings with '/' characters.
We'll pin to YARD 0.9.5 until the issue is resolved on YARD's
side.

See https://github.com/lsegal/yard/issues/1054.