### PR TITLE
Fix args handling for rake strings::generate

### DIFF
--- a/lib/puppet-strings/tasks/generate.rb
+++ b/lib/puppet-strings/tasks/generate.rb
@@ -14,8 +14,11 @@ namespace :strings do
       markup: args[:markup] || 'markdown',
     }
 
-    options[:json] = args[:json] if args.key? :json
-    options[:yard_args] = args[:yard_args].split if args.key? :yard_args
+	# rubocop:disable Style/PreferredHashMethods
+	# `args` is a Rake::TaskArguments and has no key? method
+    options[:json] = args[:json] if args.has_key? :json
+    options[:yard_args] = args[:yard_args].split if args.has_key? :yard_args
+	# rubocop:enable Style/PreferredHashMethods
 
     PuppetStrings.generate(patterns, options)
   end


### PR DESCRIPTION
In the rake task strings::generate, the arguments json and yard_args
are not applied properly. The logic uses args.key?, however args is not
a Hash but a  Rake::TaskArguments (and Enumerable). There is no key?
method.

Use Rake::TaskArguments.has_key? instead.