### PR TITLE
Use the supported ruby version for each Puppet version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,39 +8,40 @@ bundler_args: --without development acceptance
 notifications:
   email: false
 
-rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - 2.3.1
-
-env:
-  matrix:
-    - PUPPET_GEM_VERSION="~> 3.7.0" CHECK=spec
-    - PUPPET_GEM_VERSION="~> 3.8.0" CHECK=spec
-    - PUPPET_GEM_VERSION="~> 3" CHECK=spec
-    - PUPPET_GEM_VERSION="~> 4.0.0" CHECK=spec
-    - PUPPET_GEM_VERSION="~> 4.1.0" CHECK=spec
-    - PUPPET_GEM_VERSION="~> 4.2.0" CHECK=spec
-    - PUPPET_GEM_VERSION="~> 4.3.0" CHECK=spec
-    - PUPPET_GEM_VERSION="~> 4.4.0" CHECK=spec
-    - PUPPET_GEM_VERSION="~> 4.5.0" CHECK=spec
-    - PUPPET_GEM_VERSION="~> 4.6.0" CHECK=spec
-    - PUPPET_GEM_VERSION="~> 4.7.0" CHECK=spec
-    - PUPPET_GEM_VERSION="~> 4.8.0" CHECK=spec
-    - PUPPET_GEM_VERSION="~> 4" CHECK=spec
-    - PUPPET_GEM_VERSION="~> 4" CHECK=rubocop
-
-script: 'SPEC_OPTS="--format documentation" bundle exec rake $CHECK'
-
 matrix:
   fast_finish: true
-  exclude:
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 4" CHECK=rubocop
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.7.0" CHECK=spec
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.8.0" CHECK=spec
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3" CHECK=spec
+  include:
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3" CHECK=spec
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3" CHECK=spec
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 3" CHECK=spec
+  - rvm: 2.1.6
+    env: PUPPET_GEM_VERSION="~> 4.0.0" CHECK=spec
+  - rvm: 2.1.6
+    env: PUPPET_GEM_VERSION="~> 4.1.0" CHECK=spec
+  - rvm: 2.1.7
+    env: PUPPET_GEM_VERSION="~> 4.2.0" CHECK=spec
+  - rvm: 2.1.8
+    env: PUPPET_GEM_VERSION="~> 4.3.0" CHECK=spec
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4.4.0" CHECK=spec
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4.5.0" CHECK=spec
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4.6.0" CHECK=spec
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4.7.0" CHECK=spec
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4.8.0" CHECK=spec
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4.9.0" CHECK=spec
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4.10.0" CHECK=spec
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4" CHECK=spec
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4" CHECK=rubocop
+
+script: 'SPEC_OPTS="--format documentation" bundle exec rake $CHECK'


### PR DESCRIPTION
This patch moves from using a matrix of ruby and puppet version and then
excluding the incompatibilities to including supported versions. This
makes it much easier to see what is supported while also ensuring the
correct matrix of tests.

https://docs.puppet.com/puppet/4.10/about_agent.html