### PR TITLE
(QENG-5344) Add beaker-abs for CI.next-i-fication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ bundler_args: --without development acceptance
 notifications:
   email: false
 
+before_install:
+  - gem update bundler
+
 matrix:
   fast_finish: true
   include:

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :acceptance do
   gem 'beaker', '< 3.0'
   gem 'beaker-rspec'
   gem 'beaker-hostgenerator'
+  gem 'beaker-abs'
 end
 
 group :development do

--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,7 @@ task :acceptance do
 
   install_type = 'aio'
   target = ENV['platform']
+  abs = if ENV['BEAKER_ABS'] then 'abs' else 'vmpooler' end
   if ! target
     STDERR.puts 'TEST_TARGET environment variable is not set'
     STDERR.puts 'setting to default value of "centos7-64ma".'
@@ -34,7 +35,7 @@ task :acceptance do
     target += "{type=#{install_type}}"
   end
 
-  cli = BeakerHostGenerator::CLI.new([target])
+  cli = BeakerHostGenerator::CLI.new([target, '--hypervisor', abs])
   nodeset_dir = 'spec/acceptance/nodesets'
   nodeset = "#{nodeset_dir}/#{target}.yml"
   FileUtils.mkdir_p(nodeset_dir)


### PR DESCRIPTION
This is needed in order to work with always be scheduling on CI.Next jenkins instances.