### PR TITLE
Add rgen as a runtime dependency

### DIFF
--- a/puppet-strings.gemspec
+++ b/puppet-strings.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n") - Dir['.*', '*.gemspec']
 
   s.add_runtime_dependency 'yard', '~> 0.9.5'
+  s.add_runtime_dependency 'rgen'
   s.requirements << 'puppet, >= 3.7.0'
 end


### PR DESCRIPTION
When using puppet-strings with a module that otherwise does not specify rgen in its Gemfile, this error was observed:
```
$ bundle exec puppet strings generate ./manifests/*.pp
Error: The 'rgen' gem must be installed in order to use this face.
Error: Try 'puppet help strings generate' for usage
```
Adding rgen to the Gemfile allows puppet strings to work, so it seems like a valid runtime dependency.