### PR TITLE
(PDOC-233) markdown whitespace fixes

### DIFF
--- a/lib/puppet-strings/markdown/templates/classes_and_defines.erb
+++ b/lib/puppet-strings/markdown/templates/classes_and_defines.erb
@@ -24,8 +24,10 @@
 <% end -%>
 <% if examples -%>
 #### Examples
+
 <% examples.each do |eg| -%>
 ##### <%= eg[:name] %>
+
 ```puppet
 <%= eg[:text] %>
 ```

--- a/lib/puppet-strings/markdown/templates/classes_and_defines.erb
+++ b/lib/puppet-strings/markdown/templates/classes_and_defines.erb
@@ -17,8 +17,12 @@
 <% if see -%>
 * **See also**
 <% see.each do |sa| -%>
+<% if sa[:name] -%>
 <%= sa[:name] %>
+<% end -%>
+<% if sa[:text] -%>
 <%= sa[:text] %>
+<% end -%>
 <% end -%>
 
 <% end -%>
@@ -34,7 +38,7 @@
 
 <% end -%>
 <% end -%>
-<% if params %>
+<% if params -%>
 #### Parameters
 
 The following parameters are available in the `<%= name %>` <%= @type %>.
@@ -62,4 +66,3 @@ Default value: <%= value_string(defaults[param[:name]]) %>
 <% end -%>
 <% end -%>
 <% end -%>
-

--- a/lib/puppet-strings/markdown/templates/classes_and_defines.erb
+++ b/lib/puppet-strings/markdown/templates/classes_and_defines.erb
@@ -2,14 +2,12 @@
 
 <% if text -%>
 <%= text %>
-
 <% elsif summary -%>
 <%= summary %>
-
 <% else -%>
 <%= "The #{name} class." %>
-
 <% end -%>
+
 <% if since -%>
 * **Since** <%= since %>
 

--- a/lib/puppet-strings/markdown/templates/function.erb
+++ b/lib/puppet-strings/markdown/templates/function.erb
@@ -1,16 +1,15 @@
 ### <%= name %>
+
 Type: <%= type %>
 
 <% if text -%>
 <%= text %>
-
 <% elsif summary -%>
 <%= summary %>
-
 <% else -%>
 <%= "The #{name} class." %>
-
 <% end -%>
+
 <% signatures.each do |sig| -%>
 #### `<%= sig.signature %>`
 

--- a/lib/puppet-strings/markdown/templates/resource_type.erb
+++ b/lib/puppet-strings/markdown/templates/resource_type.erb
@@ -17,8 +17,12 @@
 <% if see -%>
 * **See also**
 <% see.each do |sa| -%>
+<% if sa[:name] -%>
 <%= sa[:name] %>
+<% end -%>
+<% if sa[:text] -%>
 <%= sa[:text] %>
+<% end -%>
 <% end -%>
 
 <% end -%>
@@ -114,4 +118,3 @@ Default value: <%= value_string(param[:default]) %>
 <% end -%>
 <% end -%>
 <% end -%>
-

--- a/lib/puppet-strings/markdown/templates/resource_type.erb
+++ b/lib/puppet-strings/markdown/templates/resource_type.erb
@@ -24,14 +24,17 @@
 <% end -%>
 <% if examples -%>
 #### Examples
+
 <% examples.each do |eg| -%>
 ##### <%= eg[:name] %>
+
 ```puppet
 <%= eg[:text] %>
 ```
+
 <% end -%>
 <% end -%>
-<% if properties %>
+<% if properties -%>
 #### Properties
 
 The following properties are available in the `<%= name %>` <%= @type %>.

--- a/lib/puppet-strings/markdown/templates/resource_type.erb
+++ b/lib/puppet-strings/markdown/templates/resource_type.erb
@@ -2,14 +2,12 @@
 
 <% if text -%>
 <%= text %>
-
 <% elsif summary -%>
 <%= summary %>
-
 <% else -%>
 <%= "The #{name} type." %>
-
 <% end -%>
+
 <% if since -%>
 * **Since** <%= since %>
 

--- a/lib/puppet-strings/markdown/templates/table_of_contents.erb
+++ b/lib/puppet-strings/markdown/templates/table_of_contents.erb
@@ -1,13 +1,17 @@
 <% if group.length > 0 -%>
 ## <%= group_name %>
+
 <% if priv -%>
 ### Public <%= group_name %>
+
 <% group.each do |item| -%>
 <% unless item[:private] -%>
 * [`<%= item[:name] %>`](#<%= item[:link] %>): <%= item[:desc] %>
 <% end -%>
 <% end -%>
+
 ### Private <%= group_name %>
+
 <% group.each do |item| -%>
 <% if item[:private] -%>
 * `<%= item[:name] %>`: <%= item[:desc] %>
@@ -18,4 +22,5 @@
 * [`<%= item[:name] %>`](#<%= item[:link] %>): <%= item[:desc] %>
 <% end -%>
 <% end -%>
+
 <% end -%>

--- a/spec/fixtures/unit/markdown/output.md
+++ b/spec/fixtures/unit/markdown/output.md
@@ -41,7 +41,6 @@ An overview for a simple class.
 * **See also**
 www.puppet.com
 
-
 #### Examples
 
 ##### This is an example
@@ -61,7 +60,6 @@ class { 'klass':
   param3 => 'foo',
 }
 ```
-
 
 #### Parameters
 
@@ -96,7 +94,6 @@ Third param.
 
 Default value: 'hi'
 
-
 ## Defined types
 
 ### klass::dt
@@ -108,7 +105,6 @@ An overview for a simple defined type.
 * **See also**
 www.puppet.com
 
-
 #### Examples
 
 ##### Here's an example of this type:
@@ -119,7 +115,6 @@ klass::dt { 'foo':
   param4 => false,
 }
 ```
-
 
 #### Parameters
 
@@ -159,7 +154,6 @@ Data type: `Boolean`
 Fourth param.
 
 Default value: `true`
-
 
 ## Resource types
 
@@ -210,7 +204,6 @@ Data type: `Variant[Pattern[/A(0x)?[0-9a-fA-F]{8}Z/], Pattern[/A(0x)?[0-9a-fA-F]
 _*this data type contains a regex that may not be accurately reflected in generated documentation_
 
 The ID of the key you want to manage.
-
 
 ### database
 
@@ -273,7 +266,6 @@ Valid values: `true`, `false`, yes, no
 Whether or not to encrypt the database.
 
 Default value: `false`
-
 
 ## Functions
 

--- a/spec/fixtures/unit/markdown/output.md
+++ b/spec/fixtures/unit/markdown/output.md
@@ -1,22 +1,35 @@
 # Reference
 
 ## Classes
+
 ### Public Classes
+
 * [`klass`](#klass): A simple class.
+
 ### Private Classes
+
 * `noparams`: Overview for class noparams
+
 ## Defined types
+
 * [`klass::dt`](#klassdt): A simple defined type.
+
 ## Resource types
+
 * [`apt_key`](#apt_key): Example resource type using the new API.
 * [`database`](#database): An example database server type.
+
 ## Functions
+
 * [`func`](#func): A simple Puppet function.
 * [`func3x`](#func3x): Documentation for an example 3.x function.
 * [`func4x`](#func4x): An example 4.x function.
 * [`func4x_1`](#func4x_1): An example 4.x function with only one signature.
+
 ## Tasks
+
 * [`(stdin)`](#(stdin)): Allows you to backup your database to local file.
+
 ## Classes
 
 ### klass
@@ -30,7 +43,9 @@ www.puppet.com
 
 
 #### Examples
+
 ##### This is an example
+
 ```puppet
 class { 'klass':
   param1 => 1,
@@ -39,6 +54,7 @@ class { 'klass':
 ```
 
 ##### This is another example
+
 ```puppet
 class { 'klass':
   param1 => 1,
@@ -94,7 +110,9 @@ www.puppet.com
 
 
 #### Examples
+
 ##### Here's an example of this type:
+
 ```puppet
 klass::dt { 'foo':
   param1 => 33,
@@ -155,7 +173,9 @@ If Puppet is given the location of a key file which looks like an absolute
 path this type will autorequire that file.
 
 #### Examples
+
 ##### here's an example
+
 ```puppet
 apt_key { '6F6B15509CF8E59E6E469F327F438280EF8D349F':
   source => 'http://apt.puppetlabs.com/pubkey.gpg'
@@ -197,7 +217,9 @@ The ID of the key you want to manage.
 An example database server type.
 
 #### Examples
+
 ##### here's an example
+
 ```puppet
 database { 'foo':
   address => 'qux.baz.bar',
@@ -256,6 +278,7 @@ Default value: `false`
 ## Functions
 
 ### func
+
 Type: Puppet Language
 
 A simple Puppet function.
@@ -292,6 +315,7 @@ Options:
 * **:param3opt** `Array`: Something about this option
 
 ### func3x
+
 Type: Ruby 3.x API
 
 Documentation for an example 3.x function.
@@ -315,6 +339,7 @@ Data type: `Integer`
 The second parameter.
 
 ### func4x
+
 Type: Ruby 4.x API
 
 An example 4.x function.
@@ -367,6 +392,7 @@ Data type: `Callable`
 The block parameter.
 
 ### func4x_1
+
 Type: Ruby 4.x API
 
 An example 4.x function with only one signature.

--- a/spec/fixtures/unit/markdown/output_with_plan.md
+++ b/spec/fixtures/unit/markdown/output_with_plan.md
@@ -1,22 +1,35 @@
 # Reference
 
 ## Classes
+
 ### Public Classes
+
 * [`klass`](#klass): A simple class.
+
 ### Private Classes
+
 * `noparams`: Overview for class noparams
+
 ## Defined types
+
 * [`klass::dt`](#klassdt): A simple defined type.
+
 ## Resource types
+
 * [`apt_key`](#apt_key): Example resource type using the new API.
 * [`database`](#database): An example database server type.
+
 ## Functions
+
 * [`func`](#func): A simple Puppet function.
 * [`func3x`](#func3x): Documentation for an example 3.x function.
 * [`func4x`](#func4x): An example 4.x function.
 * [`func4x_1`](#func4x_1): An example 4.x function with only one signature.
+
 ## Tasks
+
 * [`(stdin)`](#(stdin)): Allows you to backup your database to local file.
+
 ## Classes
 
 ### klass
@@ -30,7 +43,9 @@ www.puppet.com
 
 
 #### Examples
+
 ##### This is an example
+
 ```puppet
 class { 'klass':
   param1 => 1,
@@ -39,6 +54,7 @@ class { 'klass':
 ```
 
 ##### This is another example
+
 ```puppet
 class { 'klass':
   param1 => 1,
@@ -94,7 +110,9 @@ www.puppet.com
 
 
 #### Examples
+
 ##### Here's an example of this type:
+
 ```puppet
 klass::dt { 'foo':
   param1 => 33,
@@ -155,7 +173,9 @@ If Puppet is given the location of a key file which looks like an absolute
 path this type will autorequire that file.
 
 #### Examples
+
 ##### here's an example
+
 ```puppet
 apt_key { '6F6B15509CF8E59E6E469F327F438280EF8D349F':
   source => 'http://apt.puppetlabs.com/pubkey.gpg'
@@ -197,7 +217,9 @@ The ID of the key you want to manage.
 An example database server type.
 
 #### Examples
+
 ##### here's an example
+
 ```puppet
 database { 'foo':
   address => 'qux.baz.bar',
@@ -256,6 +278,7 @@ Default value: `false`
 ## Functions
 
 ### func
+
 Type: Puppet Language
 
 A simple Puppet function.
@@ -292,6 +315,7 @@ Options:
 * **:param3opt** `Array`: Something about this option
 
 ### func3x
+
 Type: Ruby 3.x API
 
 Documentation for an example 3.x function.
@@ -315,6 +339,7 @@ Data type: `Integer`
 The second parameter.
 
 ### func4x
+
 Type: Ruby 4.x API
 
 An example 4.x function.
@@ -367,6 +392,7 @@ Data type: `Callable`
 The block parameter.
 
 ### func4x_1
+
 Type: Ruby 4.x API
 
 An example 4.x function with only one signature.

--- a/spec/fixtures/unit/markdown/output_with_plan.md
+++ b/spec/fixtures/unit/markdown/output_with_plan.md
@@ -41,7 +41,6 @@ An overview for a simple class.
 * **See also**
 www.puppet.com
 
-
 #### Examples
 
 ##### This is an example
@@ -61,7 +60,6 @@ class { 'klass':
   param3 => 'foo',
 }
 ```
-
 
 #### Parameters
 
@@ -96,7 +94,6 @@ Third param.
 
 Default value: 'hi'
 
-
 ## Defined types
 
 ### klass::dt
@@ -108,7 +105,6 @@ An overview for a simple defined type.
 * **See also**
 www.puppet.com
 
-
 #### Examples
 
 ##### Here's an example of this type:
@@ -119,7 +115,6 @@ klass::dt { 'foo':
   param4 => false,
 }
 ```
-
 
 #### Parameters
 
@@ -159,7 +154,6 @@ Data type: `Boolean`
 Fourth param.
 
 Default value: `true`
-
 
 ## Resource types
 
@@ -210,7 +204,6 @@ Data type: `Variant[Pattern[/A(0x)?[0-9a-fA-F]{8}Z/], Pattern[/A(0x)?[0-9a-fA-F]
 _*this data type contains a regex that may not be accurately reflected in generated documentation_
 
 The ID of the key you want to manage.
-
 
 ### database
 
@@ -273,7 +266,6 @@ Valid values: `true`, `false`, yes, no
 Whether or not to encrypt the database.
 
 Default value: `false`
-
 
 ## Functions
 
@@ -449,7 +441,6 @@ Path to file you want backup to
 
 A simple plan.
 
-
 #### Parameters
 
 The following parameters are available in the `plann` plan.
@@ -473,5 +464,4 @@ Data type: `Integer`
 Third param.
 
 Default value: 1
-
 


### PR DESCRIPTION
- Adds blank line padding around header elements so they will render correctly with other markdown variants
- Minor updates to make whitespace consistent

I wasn't sure how to add tests for this to prevent future updates from breaking rendering.  Someone would need to know to add blank lines around headers in the output fixtures if/when they are updated.  I thought of adding a test that would read the fixture file and check the linespace padding, but if a new fixture is added (like one was recently), someone would also need to know to add a test against the new fixture.  Testing the test fixture itself is not typical and didn't feel right.