### PR TITLE
(maint) display Plans in markdown table of contents

### DIFF
--- a/lib/puppet-strings/markdown/puppet_plans.rb
+++ b/lib/puppet-strings/markdown/puppet_plans.rb
@@ -27,7 +27,7 @@ module PuppetStrings::Markdown
     def self.toc_info
       final = ["Plans"]
 
-      in_classes.each do |plan|
+      in_plans.each do |plan|
         final.push(plan.toc_info)
       end
 

--- a/lib/puppet-strings/markdown/table_of_contents.rb
+++ b/lib/puppet-strings/markdown/table_of_contents.rb
@@ -7,7 +7,8 @@ module PuppetStrings::Markdown
       PuppetStrings::Markdown::DefinedTypes,
       PuppetStrings::Markdown::ResourceTypes,
       PuppetStrings::Markdown::Functions,
-      PuppetStrings::Markdown::PuppetTasks].each do |r|
+      PuppetStrings::Markdown::PuppetTasks,
+      PuppetStrings::Markdown::PuppetPlans].each do |r|
         toc = r.toc_info
         group_name = toc.shift
         group = toc

--- a/spec/fixtures/unit/markdown/output_with_plan.md
+++ b/spec/fixtures/unit/markdown/output_with_plan.md
@@ -30,6 +30,10 @@
 
 * [`(stdin)`](#(stdin)): Allows you to backup your database to local file.
 
+## Plans
+
+* [`plann`](#plann): A simple plan.
+
 ## Classes
 
 ### klass


### PR DESCRIPTION
Currently, Plans are not being included in the table of contents in the
markdown output. This is because Plans were not being passed to the
table of contents renderer. This adds Plans to the renderer and updates
tests accordingly.