### PR TITLE
(PDOC-240) add handling for :array node type in rsapi_handler

### DIFF
--- a/lib/puppet-strings/yard/handlers/ruby/rsapi_handler.rb
+++ b/lib/puppet-strings/yard/handlers/ruby/rsapi_handler.rb
@@ -44,7 +44,7 @@ class PuppetStrings::Yard::Handlers::Ruby::RsapiHandler < PuppetStrings::Yard::H
   private
 
   def raise_parse_error(msg, location = statement)
-    raise YARD::Parser::UndocumentableError, "#{msg} at #{location.file}:#{location.line}." if parameters.empty?
+    raise YARD::Parser::UndocumentableError, "#{msg} at #{location.file}:#{location.line}."
   end
 
   # check that the params of the register_type call are key/value pairs.
@@ -67,12 +67,22 @@ class PuppetStrings::Yard::Handlers::Ruby::RsapiHandler < PuppetStrings::Yard::H
       node.source.to_i
     when :hash
       hash_from_node(node)
+    when :array
+      array_from_node(node)
     when :var_ref
       var_ref_from_node(node)
     when :symbol, :symbol_literal, :label, :dyna_symbol, :string_literal
       node_as_string(node)
     else
       raise_parse_error("unexpected construct #{node.type}")
+    end
+  end
+
+  def array_from_node(node)
+    return nil unless node
+
+    arr = node.children.collect do |assoc|
+      value_from_node(assoc.children[0])
     end
   end
 

--- a/spec/unit/puppet-strings/yard/handlers/ruby/rsapi_handler_spec.rb
+++ b/spec/unit/puppet-strings/yard/handlers/ruby/rsapi_handler_spec.rb
@@ -70,6 +70,7 @@ SOURCE
 Puppet::ResourceApi.register_type(
   name: 'database',
   docs: 'An example database server resource type.',
+  features: ['remote-resource'],
   attributes: {
     ensure: {
       type: 'Enum[present, absent, up, down]',


### PR DESCRIPTION
The 'features' key in the resource api expects an array of feature names. Currently, if you run strings on a resource api type that specifies features, it falls over because it doesn't know what to do with an AST node of type :array. Further, the method that throws the error is looking for an undefined variable called 'parameters'. This removes the odd conditional that calls 'parameters' and adds a method that returns an array of the array contents that may be passed to features. Features are not currently sent to the renderer, but now Strings will be able to handle any array it comes across in an rsapi type.