### PR TITLE
(PDOC-36) fix hack for README urls

### DIFF
--- a/lib/puppet-strings/yard/util.rb
+++ b/lib/puppet-strings/yard/util.rb
@@ -24,7 +24,7 @@ module PuppetStrings::Yard::Util
   # @return [String] HTML document with links converted
   def self.github_to_yard_links(data)
     data.scan(/href\=\"\#(.+)\"/).each do |bad_link|
-      data.gsub!(bad_link.first, "label-#{bad_link.first.capitalize.gsub('-', '+')}")
+      data.gsub!("=\"##{bad_link.first}\"", "=\"#label-#{bad_link.first.capitalize.gsub('-', '+')}\"")
     end
     data
   end

--- a/spec/unit/puppet-strings/yard/util_spec.rb
+++ b/spec/unit/puppet-strings/yard/util_spec.rb
@@ -39,5 +39,10 @@ STR
       str = '<a href="www.github.com/blah/document.html#module-description">'
       expect(subject.github_to_yard_links(str)).to eq(str)
     end
+
+    it 'leaves plain text alone' do
+      str = '<a href="#module-description"> module-description'
+      expect(subject.github_to_yard_links(str)).to eq('<a href="#label-Module+description"> module-description')
+    end
   end
 end


### PR DESCRIPTION
Discovered that this hack was finding broken links and then replacing all instances of the link text in the README. This led to a lot of non-links being affected. This patch works harder to match only actual links and works as far as I can tell.