### PR TITLE
(PDOC-259) relax ruby requirement to 2.1.0 from 2.1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,7 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 5" CHECK=spec
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4" CHECK=rubocop
+  - rvm: 2.1.0
+    env: PUPPET_GEM_VERSION="~> 4" CHECK=spec
 
 script: 'SPEC_OPTS="--format documentation" COVERAGE="yes" bundle exec rake $CHECK'

--- a/puppet-strings.gemspec
+++ b/puppet-strings.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.email = 'info@puppet.com'
   s.homepage = 'https://github.com/puppetlabs/puppet-strings'
   s.description = s.summary
-  s.required_ruby_version = '>= 2.1.9'
+  s.required_ruby_version = '>= 2.1.0'
 
   s.extra_rdoc_files = [
     'CHANGELOG.md',


### PR DESCRIPTION
This is required to support some edge-case scenarios with
older puppet versions.