### PR TITLE
Avoid clashes with PSH's build task on release

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require 'bundler/gem_tasks'
-require 'puppetlabs_spec_helper/rake_tasks'
+#require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 
 # Add our own tasks

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,11 @@ require 'bundler/gem_tasks'
 #require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.exclude_pattern = "spec/acceptance/**/*.rb"
+end
+
 # Add our own tasks
 require 'puppet-strings/tasks'
 


### PR DESCRIPTION
The (module-)`build` task from puppetlabs_spec_helper is conflicting
with the (gem-)`build` task from bundler.