### PR TITLE
Add site to default search path

### DIFF
--- a/lib/puppet-strings.rb
+++ b/lib/puppet-strings.rb
@@ -2,6 +2,7 @@
 module PuppetStrings
   # The glob patterns used to search for files to document.
   DEFAULT_SEARCH_PATTERNS = %w(
+    site/**/*.pp
     manifests/**/*.pp
     functions/**/*.pp
     types/**/*.pp


### PR DESCRIPTION
The recommended control-repo has a site directory in the top-level,
i.e. https://github.com/puppetlabs/control-repo/tree/production/site

This patch adds site to the default search path.