### PR TITLE
(maint) Reorder fixtures for test failures

### DIFF
--- a/spec/fixtures/unit/json/output.json
+++ b/spec/fixtures/unit/json/output.json
@@ -9,10 +9,6 @@
         "text": "A simple class.",
         "tags": [
           {
-            "tag_name": "todo",
-            "text": "Do a thing"
-          },
-          {
             "tag_name": "note",
             "text": "Some note"
           },
@@ -39,6 +35,10 @@
               "String"
             ],
             "name": "param3"
+          },
+          {
+            "tag_name": "todo",
+            "text": "Do a thing"
           }
         ]
       },
@@ -97,17 +97,17 @@
         "text": "This type provides Puppet with the capabilities to manage GPG keys needed\nby apt to perform package validation. Apt has it's own GPG keyring that can\nbe manipulated through the `apt-key` command.\n**Autorequires**:\nIf Puppet is given the location of a key file which looks like an absolute\npath this type will autorequire that file.",
         "tags": [
           {
-            "tag_name": "summary",
-            "text": "Example resource type using the new API."
+            "tag_name": "example",
+            "text": "apt_key { '6F6B15509CF8E59E6E469F327F438280EF8D349F':\n  source => 'http://apt.puppetlabs.com/pubkey.gpg'\n}",
+            "name": "here's an example"
           },
           {
             "tag_name": "raise",
             "text": "SomeError"
           },
           {
-            "tag_name": "example",
-            "text": "apt_key { '6F6B15509CF8E59E6E469F327F438280EF8D349F':\n  source => 'http://apt.puppetlabs.com/pubkey.gpg'\n}",
-            "name": "here's an example"
+            "tag_name": "summary",
+            "text": "Example resource type using the new API."
           }
         ]
       },

--- a/spec/fixtures/unit/json/output_with_plan.json
+++ b/spec/fixtures/unit/json/output_with_plan.json
@@ -9,10 +9,6 @@
         "text": "A simple class.",
         "tags": [
           {
-            "tag_name": "todo",
-            "text": "Do a thing"
-          },
-          {
             "tag_name": "note",
             "text": "Some note"
           },
@@ -39,6 +35,10 @@
               "String"
             ],
             "name": "param3"
+          },
+          {
+            "tag_name": "todo",
+            "text": "Do a thing"
           }
         ]
       },
@@ -97,17 +97,17 @@
         "text": "This type provides Puppet with the capabilities to manage GPG keys needed\nby apt to perform package validation. Apt has it's own GPG keyring that can\nbe manipulated through the `apt-key` command.\n**Autorequires**:\nIf Puppet is given the location of a key file which looks like an absolute\npath this type will autorequire that file.",
         "tags": [
           {
-            "tag_name": "summary",
-            "text": "Example resource type using the new API."
+            "tag_name": "example",
+            "text": "apt_key { '6F6B15509CF8E59E6E469F327F438280EF8D349F':\n  source => 'http://apt.puppetlabs.com/pubkey.gpg'\n}",
+            "name": "here's an example"
           },
           {
             "tag_name": "raise",
             "text": "SomeError"
           },
           {
-            "tag_name": "example",
-            "text": "apt_key { '6F6B15509CF8E59E6E469F327F438280EF8D349F':\n  source => 'http://apt.puppetlabs.com/pubkey.gpg'\n}",
-            "name": "here's an example"
+            "tag_name": "summary",
+            "text": "Example resource type using the new API."
           }
         ]
       },

--- a/spec/unit/puppet-strings/json_spec.rb
+++ b/spec/unit/puppet-strings/json_spec.rb
@@ -216,6 +216,8 @@ SOURCE
     it 'should output the expected JSON content' do
       Tempfile.open('json') do |file|
         PuppetStrings::Json.render(file.path)
+
+        # TODO: update expectations to validate specific content but not be sensitive to tag order, etc.
         expect(File.read(file.path)).to eq(baseline)
       end
     end
@@ -223,6 +225,7 @@ SOURCE
 
   describe 'rendering JSON to stdout' do
     it 'should output the expected JSON content' do
+      # TODO: update expectations to validate specific content but not be sensitive to tag order, etc.
       expect{ PuppetStrings::Json.render(nil) }.to output(baseline).to_stdout
     end
   end


### PR DESCRIPTION
Unit tests started failing, so this change makes them pass again,
by reordering some elements in the test fixtures.