### PR TITLE
(PDOC-272) Add required features attribute

### DIFF
--- a/lib/puppet-strings/describe.rb
+++ b/lib/puppet-strings/describe.rb
@@ -47,6 +47,8 @@ module PuppetStrings::Describe
   def self.show_one_parameter(parameter)
     puts "\n- **%{name}**\n" % { name: parameter[:name] }
     puts parameter[:description]
+    puts "Valid values are `%{values}`." % { values: parameter[:values].join("`, `") } unless parameter[:values].nil?
+    puts "Requires features %{required_features}." % { required_features: parameter[:required_features] } unless parameter[:required_features].nil?
   end
 
   def self.list_one_type(type)

--- a/lib/puppet-strings/markdown/templates/resource_type.erb
+++ b/lib/puppet-strings/markdown/templates/resource_type.erb
@@ -122,5 +122,9 @@ Options:
 Default value: <%= value_string(param[:default]) %>
 
 <% end -%>
+<% if param[:required_features] -%>
+Required features: <%= param[:required_features] %>.
+
+<% end -%>
 <% end -%>
 <% end -%>

--- a/lib/puppet-strings/yard/code_objects/type.rb
+++ b/lib/puppet-strings/yard/code_objects/type.rb
@@ -22,7 +22,7 @@ class PuppetStrings::Yard::CodeObjects::Type < PuppetStrings::Yard::CodeObjects:
   # Represents a resource type parameter.
   class Parameter
     attr_reader :name, :values, :aliases
-    attr_accessor :docstring, :isnamevar, :default, :data_type
+    attr_accessor :docstring, :isnamevar, :default, :data_type, :required_features
 
     # Initializes a resource type parameter or property.
     # @param [String] name The name of the parameter or property.
@@ -63,6 +63,7 @@ class PuppetStrings::Yard::CodeObjects::Type < PuppetStrings::Yard::CodeObjects:
       hash[:data_type] = data_type unless data_type.empty?
       hash[:aliases] = aliases unless aliases.empty?
       hash[:isnamevar] = true if isnamevar
+      hash[:required_features] = required_features if required_features
       hash[:default] = default if default
       hash
     end

--- a/lib/puppet-strings/yard/handlers/ruby/type_base.rb
+++ b/lib/puppet-strings/yard/handlers/ruby/type_base.rb
@@ -82,9 +82,17 @@ class PuppetStrings::Yard::Handlers::Ruby::TypeBase < PuppetStrings::Yard::Handl
         object.default = 'present'
       end
     end
+
+    parameters = node.parameters(false)
+
+    if parameters.count >= 2
+      kvps = parameters[1].find_all { |kvp| kvp.count == 2 }
+      required_features_kvp = kvps.find { |kvp| node_as_string(kvp[0]) == 'required_features' }
+      object.required_features = node_as_string(required_features_kvp[1]) unless required_features_kvp.nil?
+    end
+
     if object.is_a? PuppetStrings::Yard::CodeObjects::Type::Parameter
       # Process the options for parameter base types
-      parameters = node.parameters(false)
       if parameters.count >= 2
         parameters[1].each do |kvp|
           next unless kvp.count == 2

--- a/spec/fixtures/unit/json/output.json
+++ b/spec/fixtures/unit/json/output.json
@@ -178,7 +178,8 @@
         },
         {
           "name": "encryption_key",
-          "description": "The encryption key to use."
+          "description": "The encryption key to use.",
+          "required_features": "encryption"
         },
         {
           "name": "encrypt",

--- a/spec/fixtures/unit/json/output_with_plan.json
+++ b/spec/fixtures/unit/json/output_with_plan.json
@@ -178,7 +178,8 @@
         },
         {
           "name": "encryption_key",
-          "description": "The encryption key to use."
+          "description": "The encryption key to use.",
+          "required_features": "encryption"
         },
         {
           "name": "encrypt",

--- a/spec/fixtures/unit/json/output_without_puppet_function.json
+++ b/spec/fixtures/unit/json/output_without_puppet_function.json
@@ -135,7 +135,8 @@
         },
         {
           "name": "encryption_key",
-          "description": "The encryption key to use."
+          "description": "The encryption key to use.",
+          "required_features": "encryption"
         },
         {
           "name": "encrypt",

--- a/spec/fixtures/unit/markdown/output.md
+++ b/spec/fixtures/unit/markdown/output.md
@@ -266,6 +266,8 @@ The database server name.
 
 The encryption key to use.
 
+Required features: encryption.
+
 ##### `encrypt`
 
 Valid values: `true`, `false`, yes, no

--- a/spec/fixtures/unit/markdown/output_with_plan.md
+++ b/spec/fixtures/unit/markdown/output_with_plan.md
@@ -270,6 +270,8 @@ The database server name.
 
 The encryption key to use.
 
+Required features: encryption.
+
 ##### `encrypt`
 
 Valid values: `true`, `false`, yes, no

--- a/spec/unit/puppet-strings/yard/handlers/ruby/type_handler_spec.rb
+++ b/spec/unit/puppet-strings/yard/handlers/ruby/type_handler_spec.rb
@@ -72,6 +72,32 @@ SOURCE
     end
   end
 
+  describe 'parsing a type with a param with arguments' do
+    let(:source) { <<-SOURCE
+Puppet::Type.newtype(:database) do
+  feature :encryption, 'The provider supports encryption.', methods: [:encrypt]
+
+  newparam(:encryption_key, :parent => Puppet::Parameter::Boolean, required_features: :encryption) do
+    desc 'The encryption key to use.'
+    defaultto false
+  end
+end
+SOURCE
+    }
+
+    it 'should correctly detect the required_feature' do
+      expect(subject.size).to eq(1)
+      object = subject.first
+      expect(object.parameters[0].required_features).to eq('encryption')
+    end
+
+    it 'should correctly detect a boolean parent' do
+      expect(subject.size).to eq(1)
+      object = subject.first
+      expect(object.parameters[0].default).to eq('false')
+    end
+  end
+
   describe 'parsing a type definition' do
     let(:source) { <<-SOURCE
 # @!puppet.type.param [value1, value2] dynamic_param Documentation for a dynamic parameter.


### PR DESCRIPTION
With this change, the required_features argument to newparam and newproperty is parsed.
This data is added to YARD objects and the to_hash output.  It is also added to results
for describe, json, and markdown rendering.
