### PR TITLE
(maint) Add Puppet 6 to testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,15 @@ before_install:
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.1.9
+  - rvm: 2.1.0
     env: PUPPET_GEM_VERSION="~> 4" CHECK=spec
   - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 4" CHECK=spec
   - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 5" CHECK=spec
+  - rvm: 2.5
+    env: PUPPET_GEM_VERSION="~> 6" CHECK=spec
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4" CHECK=rubocop
-  - rvm: 2.1.0
-    env: PUPPET_GEM_VERSION="~> 4" CHECK=spec
 
 script: 'SPEC_OPTS="--format documentation" COVERAGE="yes" bundle exec rake $CHECK'


### PR DESCRIPTION
This commit updates the test matix to include Puppet 6.  This commit also
removes the 2.1.9 testing on Puppet 4 as this is already performed with the
ruby 2.1.0 testing.  There is no need to test twice (162 examples in both cells)