### PR TITLE
(maint) Update very old Beaker version in Gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.1.0
+  - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4" CHECK=spec
   - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 4" CHECK=spec

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
 end
 
 group :acceptance do
-  gem 'beaker', '~> 3.0'
+  gem 'beaker', '~> 3.37'
   gem 'beaker-rspec'
   gem 'beaker-hostgenerator'
   gem 'beaker-abs'


### PR DESCRIPTION
Currently beaker is pinned at version 2.x which causes issues on Windows with
modern Ruby.  Beaker 2.x pulls in VERY old versions of nokogiri which cannot
be compiled on Windows.  This commit updates the Beaker version pin to version
3.x as this has been out for over a year, and will allow developers on Windows
to at least do a bundle install.  Later commits may update this to the latest
beaker version (4.x)