### PR TITLE
(maint) Allow local Gemfile overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tmtags
 
 ## BUNDLER
 .bundle
+Gemfile.local
 Gemfile.lock
 
 ## YARD

--- a/Gemfile
+++ b/Gemfile
@@ -36,3 +36,13 @@ group :development do
 end
 
 gem 'rubocop', '~> 0.49'
+
+# Evaluate Gemfile.local if it exists
+if File.exists? "#{__FILE__}.local"
+  eval(File.read("#{__FILE__}.local"), binding)
+end
+
+# Evaluate ~/.gemfile if it exists
+if File.exists?(File.join(Dir.home, '.gemfile'))
+  eval(File.read(File.join(Dir.home, '.gemfile')), binding)
+end


### PR DESCRIPTION
Developers may want to use additional gems during development.  This commit
updates the Gemfile to allow user and project additions to be added without the
need to checkin the Gemfile.  This is a common pattern used within Puppet.