### PR TITLE
(PDOC-283) Fix namespaced symbols

### DIFF
--- a/lib/puppet-strings/yard/handlers/ruby/base.rb
+++ b/lib/puppet-strings/yard/handlers/ruby/base.rb
@@ -18,7 +18,13 @@ class PuppetStrings::Yard::Handlers::Ruby::Base < YARD::Handlers::Ruby::Base
     when :label
       node.source[0..-2]
     when :dyna_symbol
-      node.source
+      # YARD 0.9.20 changed how dyna_symbols are represented
+      # https://github.com/lsegal/yard/commit/225ded9ef38c6d2be5a3b0fc7effbc7d6644768d
+      if yard_version >= Gem::Version.new('0.9.20')
+        node.source[2..-2]
+      else
+        node.source
+      end
     when :string_literal
       content = node.jump(:tstring_content)
       return content.source if content != node
@@ -46,4 +52,9 @@ class PuppetStrings::Yard::Handlers::Ruby::Base < YARD::Handlers::Ruby::Base
     name
   end
 
+  private
+
+  def yard_version
+    @yard_version ||= Gem::Version.new(YARD::VERSION)
+  end
 end

--- a/spec/unit/puppet-strings/yard/handlers/ruby/function_handler_spec.rb
+++ b/spec/unit/puppet-strings/yard/handlers/ruby/function_handler_spec.rb
@@ -567,6 +567,23 @@ end
     end
   end
 
+  describe 'parsing a function with a namespaced name' do
+    let(:source) { <<-SOURCE
+# An example 4.x function.
+Puppet::Functions.create_function(:'foo::bar::baz') do
+  # @return [Undef]
+  dispatch :foo do
+  end
+end
+    SOURCE
+    }
+
+    it 'should output the name correctly as a symbol' do
+      expect(subject.size).to eq(1)
+      expect(subject.first.name).to eq(:'foo::bar::baz')
+    end
+  end
+
   describe 'parsing a function with a missing parameter' do
     let(:source) { <<-SOURCE
 # An example 4.x function.

--- a/spec/unit/puppet-strings/yard/handlers/ruby/provider_handler_spec.rb
+++ b/spec/unit/puppet-strings/yard/handlers/ruby/provider_handler_spec.rb
@@ -106,6 +106,25 @@ end
     end
   end
 
+  describe 'parsing a provider definition with a string based name' do
+    let(:source) { <<-SOURCE
+Puppet::Type.type(:'custom').provide :'linux' do
+  desc 'An example provider on Linux.'
+end
+    SOURCE
+    }
+
+    it 'should register a provider object' do
+      expect(subject.size).to eq(1)
+      object = subject.first
+      expect(object).to be_a(PuppetStrings::Yard::CodeObjects::Provider)
+      expect(object.namespace).to eq(PuppetStrings::Yard::CodeObjects::Providers.instance('custom'))
+      expect(object.name).to eq(:linux)
+      expect(object.type_name).to eq('custom')
+      expect(object.docstring).to eq('An example provider on Linux.')
+    end
+  end
+
   describe 'parsing a provider with a summary' do
     context 'when the summary has fewer than 140 characters' do
       let(:source) { <<-SOURCE

--- a/spec/unit/puppet-strings/yard/handlers/ruby/type_handler_spec.rb
+++ b/spec/unit/puppet-strings/yard/handlers/ruby/type_handler_spec.rb
@@ -223,6 +223,22 @@ end
     end
   end
 
+  describe 'parsing a valid type with string based name' do
+    let(:source) { <<-SOURCE
+Puppet::Type.newtype(:'database') do
+  desc 'An example database server resource type.'
+  ensurable
+end
+    SOURCE
+    }
+
+    it 'should register a type object with default ensure values' do
+      expect(subject.size).to eq(1)
+      object = subject.first
+      expect(object.name).to eq(:database)
+    end
+  end
+
   describe 'parsing an ensurable type with default ensure values' do
     let(:source) { <<-SOURCE
 Puppet::Type.newtype(:database) do


### PR DESCRIPTION
Previously in Yard 0.9.19 dyna_symbols (symbols represented as strings e.g.
:'something') were converted to their unqualified symbol name e.g. :something.
However YARD treated this as a bug and in Yard 0.19.20 dynasymbols are now their
original source.  This commit modifies the base ruby handler to always convert
dyna_symbols to their plain name, as Puppet uses this for actual documentation
and Puppet Code.  For example the fully qualified function 'foo::bar' will
appear in the ruby function definition as `.. :'foo::bar'` however in the Puppet
documentation the name should appears as `foo::bar`.

This commit also adds tests for this scenario as there were no existing tests
for this.