### PR TITLE
(PDOC-283) Use AST to determine dyna_symbols

### DIFF
--- a/lib/puppet-strings/yard/handlers/ruby/base.rb
+++ b/lib/puppet-strings/yard/handlers/ruby/base.rb
@@ -18,13 +18,8 @@ class PuppetStrings::Yard::Handlers::Ruby::Base < YARD::Handlers::Ruby::Base
     when :label
       node.source[0..-2]
     when :dyna_symbol
-      # YARD 0.9.20 changed how dyna_symbols are represented
-      # https://github.com/lsegal/yard/commit/225ded9ef38c6d2be5a3b0fc7effbc7d6644768d
-      if yard_version >= Gem::Version.new('0.9.20')
-        node.source[2..-2]
-      else
-        node.source
-      end
+      content = node.jump(:tstring_content)
+      content.nil? ? node.source : content.source
     when :string_literal
       content = node.jump(:tstring_content)
       return content.source if content != node


### PR DESCRIPTION
Previously the base handler used a naive method to determine the name of a
dyna_symbol.  This commit updates the handler to instead use the actual ruby
AST to determine the string content.  This was tested on ruby 0.9.20 and
0.9.19.  No tests were changed as there is no change in behaviour.