### PR TITLE
(maint) Remove unused yard_version method

### DIFF
--- a/lib/puppet-strings/yard/handlers/ruby/base.rb
+++ b/lib/puppet-strings/yard/handlers/ruby/base.rb
@@ -46,10 +46,4 @@ class PuppetStrings::Yard::Handlers::Ruby::Base < YARD::Handlers::Ruby::Base
     raise YARD::Parser::UndocumentableError, "Expected a symbol or string literal for first parameter but found '#{parameters.first.type}' at #{statement.file}:#{statement.line}." unless name
     name
   end
-
-  private
-
-  def yard_version
-    @yard_version ||= Gem::Version.new(YARD::VERSION)
-  end
 end


### PR DESCRIPTION
Now that ruby AST is used to determine the string content for function names we no longer need to detect yard version.