### PR TITLE
(maint) Use parameters method instead of json['parameters']

### DIFF
--- a/lib/puppet-strings/yard/code_objects/task.rb
+++ b/lib/puppet-strings/yard/code_objects/task.rb
@@ -43,7 +43,7 @@ class PuppetStrings::Yard::CodeObjects::Task < PuppetStrings::Yard::CodeObjects:
 
   def parameters
     parameters = []
-    statement.json['parameters'].each do |name,props|
+    statement.parameters.each do |name,props|
       parameters.push({ name: name.to_s,
                         tag_name: 'param',
                         text: props['description'] || "",

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -25,7 +25,7 @@ else
     options[:port] = node_config.dig('ssh', 'port') unless node_config.dig('ssh', 'port').nil?
     options[:keys] = node_config.dig('ssh', 'private-key') unless node_config.dig('ssh', 'private-key').nil?
     options[:password] = node_config.dig('ssh', 'password') unless node_config.dig('ssh', 'password').nil?
-    options[:verify_host_key] = Net::SSH::Verifiers::Null.new unless node_config.dig('ssh', 'host-key-check').nil?
+    options[:verify_host_key] = Net::SSH::Verifiers::Never.new unless node_config.dig('ssh', 'host-key-check').nil?
     host = if ENV['TARGET_HOST'].include?(':')
              ENV['TARGET_HOST'].split(':').first
            else


### PR DESCRIPTION
When a task doesn't have parameters and a user generates markdown for
the task, this line would error because it can't iterate on `nil`. This
modifies it to use the `TaskStatement` method `parameters` which sets a
default empty hash when a task doesn't have parameters.