### PR TITLE
(PDOC-295) Add @enum tag support for Enum data types

### DIFF
--- a/lib/puppet-strings/markdown/base.rb
+++ b/lib/puppet-strings/markdown/base.rb
@@ -111,12 +111,25 @@ module PuppetStrings::Markdown
       select_tags('option')
     end
 
+    # @return [Array] enum tag hashes
+    def enums
+      select_tags('enum')
+    end
+
     # @param parameter_name
     #   parameter name to match to option tags
     # @return [Array] option tag hashes that have a parent parameter_name
     def options_for_param(parameter_name)
       opts_for_p = options.select { |o| o[:parent] == parameter_name } unless options.nil?
       opts_for_p unless opts_for_p.nil? || opts_for_p.length.zero?
+    end
+
+    # @param parameter_name
+    #   parameter name to match to enum tags
+    # @return [Array] enum tag hashes that have a parent parameter_name
+    def enums_for_param(parameter_name)
+      enums_for_p = enums.select { |e| e[:parent] == parameter_name } unless enums.nil?
+      enums_for_p unless enums_for_p.nil? || enums_for_p.length.zero?
     end
 
     # @return [Hash] any defaults found for the component

--- a/lib/puppet-strings/markdown/templates/classes_and_defines.erb
+++ b/lib/puppet-strings/markdown/templates/classes_and_defines.erb
@@ -66,6 +66,14 @@ Options:
 <% end -%>
 
 <% end -%>
+<% if enums_for_param(param[:name]) -%>
+Options:
+
+<% enums_for_param(param[:name]).each do |e| -%>
+* **<%= e[:opt_name] %>**: <%= e[:opt_text] %>
+<% end -%>
+
+<% end -%>
 <% if defaults && defaults[param[:name]] -%>
 Default value: <%= value_string(defaults[param[:name]]) %>
 

--- a/lib/puppet-strings/markdown/templates/data_type.erb
+++ b/lib/puppet-strings/markdown/templates/data_type.erb
@@ -70,6 +70,14 @@ Options:
 <% end -%>
 
 <% end -%>
+<% if enums_for_param(param[:name]) -%>
+Options:
+
+<% enums_for_param(param[:name]).each do |e| -%>
+* **<%= e[:opt_name] %>**: <%= e[:opt_text] %>
+<% end -%>
+
+<% end -%>
 <% if defaults && defaults[param[:name]] -%>
 Default value: <%= value_string(defaults[param[:name]]) %>
 

--- a/lib/puppet-strings/markdown/templates/function.erb
+++ b/lib/puppet-strings/markdown/templates/function.erb
@@ -88,6 +88,14 @@ Options:
 <% end -%>
 
 <% end -%>
+<% if sig.enums_for_param(param[:name]) -%>
+Options:
+
+<% sig.enums_for_param(param[:name]).each do |e| -%>
+* **<%= e[:opt_name] %>**: <%= e[:opt_text] %>
+<% end -%>
+
+<% end -%>
 <% end -%>
 <% end -%>
 <% end -%>

--- a/lib/puppet-strings/markdown/templates/resource_type.erb
+++ b/lib/puppet-strings/markdown/templates/resource_type.erb
@@ -78,6 +78,14 @@ Options:
 <% end -%>
 
 <% end -%>
+<% if enums_for_param(prop[:name]) -%>
+Options:
+
+<% enums_for_param(prop[:name]).each do |e| -%>
+* **<%= e[:opt_name] %>**: <%= e[:opt_text] %>
+<% end -%>
+
+<% end -%>
 <% if prop[:default] -%>
 Default value: <%= prop[:default] %>
 
@@ -115,6 +123,14 @@ Options:
 
 <% options_for_param(param[:name]).each do |o| -%>
 * **<%= o[:opt_name] %>** `<%= o[:opt_types][0] %>`: <%= o[:opt_text] %>
+<% end -%>
+
+<% end -%>
+<% if enums_for_param(param[:name]) -%>
+Options:
+
+<% enums_for_param(param[:name]).each do |e| -%>
+* **<%= e[:opt_name] %>**: <%= e[:opt_text] %>
 <% end -%>
 
 <% end -%>

--- a/lib/puppet-strings/yard.rb
+++ b/lib/puppet-strings/yard.rb
@@ -11,6 +11,9 @@ module PuppetStrings::Yard
   # Sets up YARD for use with puppet-strings.
   # @return [void]
   def self.setup!
+    # Register our factory
+    YARD::Tags::Library.default_factory = PuppetStrings::Yard::Tags::Factory
+
     # Register the template path
     YARD::Templates::Engine.register_template_path(File.join(File.dirname(__FILE__), 'yard', 'templates'))
 
@@ -29,6 +32,9 @@ module PuppetStrings::Yard
 
     # Register the summary tag
     PuppetStrings::Yard::Tags::SummaryTag.register!
+
+    # Register the enum tag
+    PuppetStrings::Yard::Tags::EnumTag.register!
 
     # Ignore documentation on Puppet DSL calls
     # This prevents the YARD DSL parser from emitting warnings for Puppet's Ruby DSL

--- a/lib/puppet-strings/yard/code_objects/function.rb
+++ b/lib/puppet-strings/yard/code_objects/function.rb
@@ -88,10 +88,10 @@ class PuppetStrings::Yard::CodeObjects::Function < PuppetStrings::Yard::CodeObje
     if self.has_tag? :overload
       # loop over overloads and append onto the signatures array
       self.tags(:overload).each do |o|
-        hash[:signatures] << { :signature => o.signature, :docstring => PuppetStrings::Yard::Util.docstring_to_hash(o.docstring, %i[param option return example]) }
+        hash[:signatures] << { :signature => o.signature, :docstring => PuppetStrings::Yard::Util.docstring_to_hash(o.docstring, %i[param option enum return example]) }
       end
     else
-      hash[:signatures] << { :signature => self.signature, :docstring =>  PuppetStrings::Yard::Util.docstring_to_hash(docstring, %i[param option return example]) }
+      hash[:signatures] << { :signature => self.signature, :docstring =>  PuppetStrings::Yard::Util.docstring_to_hash(docstring, %i[param option enum return example]) }
     end
 
     hash[:docstring] = PuppetStrings::Yard::Util.docstring_to_hash(docstring)

--- a/lib/puppet-strings/yard/tags.rb
+++ b/lib/puppet-strings/yard/tags.rb
@@ -1,7 +1,9 @@
 # The module for custom YARD tags.
 module PuppetStrings::Yard::Tags
+  require 'puppet-strings/yard/tags/factory'
   require 'puppet-strings/yard/tags/parameter_directive'
   require 'puppet-strings/yard/tags/property_directive'
   require 'puppet-strings/yard/tags/overload_tag'
   require 'puppet-strings/yard/tags/summary_tag'
+  require 'puppet-strings/yard/tags/enum_tag'
 end

--- a/lib/puppet-strings/yard/tags/enum_tag.rb
+++ b/lib/puppet-strings/yard/tags/enum_tag.rb
@@ -1,0 +1,11 @@
+require 'yard/tags/option_tag'
+
+# Implements an enum tag for describing enumerated value data types
+
+class PuppetStrings::Yard::Tags::EnumTag < YARD::Tags::OptionTag
+  # Registers the tag with YARD.
+  # @return [void]
+  def self.register!
+    YARD::Tags::Library.define_tag("puppet.enum", :enum, :with_enums)
+  end
+end

--- a/lib/puppet-strings/yard/tags/factory.rb
+++ b/lib/puppet-strings/yard/tags/factory.rb
@@ -1,0 +1,16 @@
+require 'yard/tags/default_factory'
+require 'puppet-strings/yard/tags/enum_tag'
+
+class PuppetStrings::Yard::Tags::Factory < YARD::Tags::DefaultFactory
+
+  # Parses tag text and creates a new enum tag type. Modeled after
+  # the parse_tag_with_options method in YARD::Tags::DefaultFactory.
+  #
+  # @param tag_name        the name of the tag to parse
+  # @param [String] text   the raw tag text
+  # @return [Tag]          a tag object with the tag_name, name, and nested Tag as type
+  def parse_tag_with_enums(tag_name, text)
+    name, text = *extract_name_from_text(text)
+    PuppetStrings::Yard::Tags::EnumTag.new(tag_name, name, parse_tag_with_name(tag_name, text))
+  end
+end

--- a/lib/puppet-strings/yard/util.rb
+++ b/lib/puppet-strings/yard/util.rb
@@ -38,11 +38,11 @@ module PuppetStrings::Yard::Util
       next t.to_hash if t.respond_to?(:to_hash)
 
       tag = { tag_name: t.tag_name }
-      # grab nested information for @option tags
-      if tag[:tag_name] == 'option'
+      # grab nested information for @option and @enum tags
+      if tag[:tag_name] == 'option' || tag[:tag_name] == 'enum'
         tag[:opt_name] = t.pair.name
         tag[:opt_text] = t.pair.text
-        tag[:opt_types] = t.pair.types
+        tag[:opt_types] = t.pair.types if t.pair.types
         tag[:parent] = t.name
       end
       tag[:text] = t.text if t.text

--- a/spec/fixtures/unit/markdown/output.md
+++ b/spec/fixtures/unit/markdown/output.md
@@ -101,6 +101,19 @@ Third param.
 
 Default value: 'hi'
 
+##### `param4`
+
+Data type: `Enum['one', 'two']`
+
+Fourth param.
+
+Options:
+
+* **:one**: One option
+* **:two**: Second option
+
+Default value: 'two'
+
 ## Defined types
 
 ### klass::dt
@@ -161,6 +174,19 @@ Data type: `Boolean`
 Fourth param.
 
 Default value: `true`
+
+##### `param5`
+
+Data type: `Enum['a', 'b']`
+
+Fifth param.
+
+Options:
+
+* **:a**: Option A
+* **:b**: Option B
+
+Default value: 'a'
 
 ## Resource types
 
@@ -238,6 +264,11 @@ Aliases: "up"=>"present", "down"=>"absent"
 
 What state the database should be in.
 
+Options:
+
+* **:up**: Upstate
+* **:down**: Downstate
+
 Default value: up
 
 ##### `file`
@@ -292,7 +323,7 @@ A simple Puppet function.
 $result = func(1, 2)
 ```
 
-#### `func(Integer $param1, Any $param2, String $param3 = hi)`
+#### `func(Integer $param1, Any $param2, String $param3 = hi, Enum['yes', 'no'] $param4 = 'yes')`
 
 A simple Puppet function.
 
@@ -330,6 +361,17 @@ Third param.
 Options:
 
 * **:param3opt** `Array`: Something about this option
+
+##### `param4`
+
+Data type: `Enum['yes', 'no']`
+
+Fourth param.
+
+Options:
+
+* **:yes**: Yes option.
+* **:no**: No option.
 
 ### func3x
 
@@ -391,7 +433,7 @@ $result = func4x(1, 'foo')
 $result = func4x(1, 'foo', ['bar'])
 ```
 
-#### `func4x(Integer $param1, Any $param2, Optional[Array[String]] $param3)`
+#### `func4x(Integer $param1, Any $param2, Optional[Array[String]] $param3, Optional[Enum[one, two]] $param4)`
 
 An overview for the first overload.
 
@@ -427,6 +469,17 @@ Options:
 Data type: `Optional[Array[String]]`
 
 The third parameter.
+
+##### `param4`
+
+Data type: `Optional[Enum[one, two]]`
+
+The fourth parameter.
+
+Options:
+
+* **:one**: Option one.
+* **:two**: Option two.
 
 #### `func4x(Boolean $param, Callable &$block)`
 

--- a/spec/fixtures/unit/markdown/output_with_data_types.md
+++ b/spec/fixtures/unit/markdown/output_with_data_types.md
@@ -107,6 +107,19 @@ Third param.
 
 Default value: 'hi'
 
+##### `param4`
+
+Data type: `Enum['one', 'two']`
+
+Fourth param.
+
+Options:
+
+* **:one**: One option
+* **:two**: Second option
+
+Default value: 'two'
+
 ## Defined types
 
 ### klass::dt
@@ -167,6 +180,19 @@ Data type: `Boolean`
 Fourth param.
 
 Default value: `true`
+
+##### `param5`
+
+Data type: `Enum['a', 'b']`
+
+Fifth param.
+
+Options:
+
+* **:a**: Option A
+* **:b**: Option B
+
+Default value: 'a'
 
 ## Resource types
 
@@ -244,6 +270,11 @@ Aliases: "up"=>"present", "down"=>"absent"
 
 What state the database should be in.
 
+Options:
+
+* **:up**: Upstate
+* **:down**: Downstate
+
 Default value: up
 
 ##### `file`
@@ -298,7 +329,7 @@ A simple Puppet function.
 $result = func(1, 2)
 ```
 
-#### `func(Integer $param1, Any $param2, String $param3 = hi)`
+#### `func(Integer $param1, Any $param2, String $param3 = hi, Enum['yes', 'no'] $param4 = 'yes')`
 
 A simple Puppet function.
 
@@ -336,6 +367,17 @@ Third param.
 Options:
 
 * **:param3opt** `Array`: Something about this option
+
+##### `param4`
+
+Data type: `Enum['yes', 'no']`
+
+Fourth param.
+
+Options:
+
+* **:yes**: Yes option.
+* **:no**: No option.
 
 ### func3x
 
@@ -397,7 +439,7 @@ $result = func4x(1, 'foo')
 $result = func4x(1, 'foo', ['bar'])
 ```
 
-#### `func4x(Integer $param1, Any $param2, Optional[Array[String]] $param3)`
+#### `func4x(Integer $param1, Any $param2, Optional[Array[String]] $param3, Optional[Enum[one, two]] $param4)`
 
 An overview for the first overload.
 
@@ -433,6 +475,17 @@ Options:
 Data type: `Optional[Array[String]]`
 
 The third parameter.
+
+##### `param4`
+
+Data type: `Optional[Enum[one, two]]`
+
+The fourth parameter.
+
+Options:
+
+* **:one**: Option one.
+* **:two**: Option two.
 
 #### `func4x(Boolean $param, Callable &$block)`
 

--- a/spec/fixtures/unit/markdown/output_with_plan.md
+++ b/spec/fixtures/unit/markdown/output_with_plan.md
@@ -105,6 +105,19 @@ Third param.
 
 Default value: 'hi'
 
+##### `param4`
+
+Data type: `Enum['one', 'two']`
+
+Fourth param.
+
+Options:
+
+* **:one**: One option
+* **:two**: Second option
+
+Default value: 'two'
+
 ## Defined types
 
 ### klass::dt
@@ -165,6 +178,19 @@ Data type: `Boolean`
 Fourth param.
 
 Default value: `true`
+
+##### `param5`
+
+Data type: `Enum['a', 'b']`
+
+Fifth param.
+
+Options:
+
+* **:a**: Option A
+* **:b**: Option B
+
+Default value: 'a'
 
 ## Resource types
 
@@ -242,6 +268,11 @@ Aliases: "up"=>"present", "down"=>"absent"
 
 What state the database should be in.
 
+Options:
+
+* **:up**: Upstate
+* **:down**: Downstate
+
 Default value: up
 
 ##### `file`
@@ -296,7 +327,7 @@ A simple Puppet function.
 $result = func(1, 2)
 ```
 
-#### `func(Integer $param1, Any $param2, String $param3 = hi)`
+#### `func(Integer $param1, Any $param2, String $param3 = hi, Enum['yes', 'no'] $param4 = 'yes')`
 
 A simple Puppet function.
 
@@ -334,6 +365,17 @@ Third param.
 Options:
 
 * **:param3opt** `Array`: Something about this option
+
+##### `param4`
+
+Data type: `Enum['yes', 'no']`
+
+Fourth param.
+
+Options:
+
+* **:yes**: Yes option.
+* **:no**: No option.
 
 ### func3x
 
@@ -395,7 +437,7 @@ $result = func4x(1, 'foo')
 $result = func4x(1, 'foo', ['bar'])
 ```
 
-#### `func4x(Integer $param1, Any $param2, Optional[Array[String]] $param3)`
+#### `func4x(Integer $param1, Any $param2, Optional[Array[String]] $param3, Optional[Enum[one, two]] $param4)`
 
 An overview for the first overload.
 
@@ -431,6 +473,17 @@ Options:
 Data type: `Optional[Array[String]]`
 
 The third parameter.
+
+##### `param4`
+
+Data type: `Optional[Enum[one, two]]`
+
+The fourth parameter.
+
+Options:
+
+* **:one**: Option one.
+* **:two**: Option two.
 
 #### `func4x(Boolean $param, Callable &$block)`
 

--- a/spec/unit/puppet-strings/markdown_spec.rb
+++ b/spec/unit/puppet-strings/markdown_spec.rb
@@ -29,11 +29,15 @@ describe PuppetStrings::Markdown do
 # @option param2 [String] :opt1 something about opt1
 # @option param2 [Hash] :opt2 a hash of stuff
 # @param param3 Third param.
+# @param param4 Fourth param.
+# @enum param4 :one One option
+# @enum param4 :two Second option
 #
 class klass (
   Integer $param1 = 1,
   $param2 = undef,
-  String $param3 = 'hi'
+  String $param3 = 'hi',
+  Enum['one', 'two'] $param4 = 'two',
 ) inherits foo::bar {
 }
 
@@ -58,11 +62,15 @@ class noparams () {}
 # @option param2 [Hash] :opt2 a hash of stuff
 # @param param3 Third param.
 # @param param4 Fourth param.
+# @param param5 Fifth param.
+# @enum param5 :a Option A
+# @enum param5 :b Option B
 define klass::dt (
   Integer $param1 = 44,
   $param2,
   String $param3 = 'hi',
-  Boolean $param4 = true
+  Boolean $param4 = true,
+  Enum['a', 'b'] $param5 = 'a'
 ) {
 }
     SOURCE
@@ -98,11 +106,14 @@ define klass::dt (
 # @param param2 Second param.
 # @param param3 Third param.
 # @option param3 [Array] :param3opt Something about this option
+# @param param4 Fourth param.
+# @enum param4 :yes Yes option.
+# @enum param4 :no No option.
 # @raise SomeError this is some error
 # @return [Undef] Returns nothing.
 # @example Test
 #   $result = func(1, 2)
-function func(Integer $param1, $param2, String $param3 = hi) {
+function func(Integer $param1, $param2, String $param3 = hi, Enum['yes', 'no'] $param4 = 'yes') {
 }
     SOURCE
 
@@ -122,6 +133,9 @@ Puppet::Functions.create_function(:func4x) do
   # @option param2 [String] :option an option
   # @option param2 [String] :option2 another option
   # @param param3 The third parameter.
+  # @param param4 The fourth parameter.
+  # @enum param4 :one Option one.
+  # @enum param4 :two Option two.
   # @return Returns nothing.
   # @example Calling the function foo
   #   $result = func4x(1, 'foooo')
@@ -130,6 +144,7 @@ Puppet::Functions.create_function(:func4x) do
     param          'Integer',       :param1
     param          'Any',           :param2
     optional_param 'Array[String]', :param3
+    optional_param 'Enum[one, two]', :param4
     return_type 'Undef'
   end
 
@@ -183,6 +198,8 @@ Puppet::Type.newtype(:database) do
   desc <<-DESC
 An example database server type.
 @option opts :foo bar
+@enum ensure :up Upstate
+@enum ensure :down Downstate
 @raise SomeError
 @example here's an example
  database { 'foo':


### PR DESCRIPTION
`Enum` data types would benefit from the ability to add extended
documentation on each option similarly to the `@option` tag
for hashes. The `@option` type is not a good fit for `Enum` data
type parameters as it requires data types to be specified,
which doesn't make sense in the context of an `Enum` type.

This patch adds a new `@enum` tag which behaves like @option,
but does not accept the data type parameter that `@option` does.