### PR TITLE
Add missing HTML output support for enum tag

### DIFF
--- a/lib/puppet-strings/yard/tags/enum_tag.rb
+++ b/lib/puppet-strings/yard/tags/enum_tag.rb
@@ -7,5 +7,6 @@ class PuppetStrings::Yard::Tags::EnumTag < YARD::Tags::OptionTag
   # @return [void]
   def self.register!
     YARD::Tags::Library.define_tag("puppet.enum", :enum, :with_enums)
+    YARD::Tags::Library.visible_tags.place(:enum).after(:option)
   end
 end

--- a/lib/puppet-strings/yard/templates/default/tags/html/enum.erb
+++ b/lib/puppet-strings/yard/templates/default/tags/html/enum.erb
@@ -1,0 +1,17 @@
+<% if object.has_tag?(:enum) %>
+  <% object.parameters.each do |param, default| %>
+    <% tags = object.tags(:enum).select {|x| x.name.to_s == param.to_s.sub(/^\*+|:$/, '') } %>
+    <% next if tags.empty? %>
+    <p class="tag_title">Enum Options (<tt><%= param %></tt>):</p>
+    <ul class="option">
+      <% for tag in tags %>
+        <li>
+          <span class="name"><%= tag.pair.name %></span>
+          <% if tag.pair.text && tag.pair.text =~ /\S/ %>
+            &mdash; <%= htmlify_line(tag.pair.text) %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>

--- a/lib/puppet-strings/yard/templates/default/tags/setup.rb
+++ b/lib/puppet-strings/yard/templates/default/tags/setup.rb
@@ -16,3 +16,9 @@ end
 def overload
   erb(if object.type == :puppet_function then :puppet_overload else :overload end)
 end
+
+# Renders the enum section.
+# @return [String] Returns the rendered section.
+def enum
+  erb(:enum)
+end

--- a/spec/acceptance/running_strings_generate_spec.rb
+++ b/spec/acceptance/running_strings_generate_spec.rb
@@ -75,4 +75,14 @@ describe 'Generating module documentation using generate action' do
       'A simple elephant type.',
     ])
   end
+
+  it 'should generate documentation for enum tag' do
+    expect_file_contain('doc/puppet_classes/test.html', [
+      '<p class="tag_title">Enum Options (<tt>myenum</tt>):</p>',
+      '<span class="name">a</span>',
+      "&mdash; <div class='inline'>\n<p>Option A</p>\n</div>",
+      '<span class="name">b</span>',
+      "&mdash; <div class='inline'>\n<p>Option B</p>\n</div>",
+    ])
+  end
 end

--- a/spec/fixtures/acceptance/modules/test/manifests/init.pp
+++ b/spec/fixtures/acceptance/modules/test/manifests/init.pp
@@ -7,9 +7,13 @@
 #
 # @param package_name The name of the package
 # @param service_name The name of the service
+# @param enum
+# @enum myenum a Option A
+# @enum myenum b Option B
 class test (
   $package_name = $test::params::package_name,
   $service_name = $test::params::service_name,
+  Enum['a', 'b'] $myenum = 'a',
 
 ) inherits test::params {
 

--- a/spec/fixtures/acceptance/modules/test/manifests/init.pp
+++ b/spec/fixtures/acceptance/modules/test/manifests/init.pp
@@ -7,7 +7,7 @@
 #
 # @param package_name The name of the package
 # @param service_name The name of the service
-# @param enum
+# @param myenum
 # @enum myenum a Option A
 # @enum myenum b Option B
 class test (


### PR DESCRIPTION
In #215 support for the new `enum` tag was added. Unfortunately, all of the testing was with markdown generation and it escaped me that HTML output was not automatically included. This patch adds the HTML output generation for the `enum` tag which should have been included in #215 