### PR TITLE
(MAINT) Fix litmus testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
     before_script:
     - bundle exec rake 'litmus:provision[docker, centos:7]'
     - bundle exec rake 'litmus:install_agent[puppet6]'
-    - bundle exec rake litmus:install_module_fixtures
+    - bundle exec rake 'litmus:install_modules_from_directory[./spec/fixtures/acceptance/modules]'
     - bundle exec rake litmus:install_gems
     script:
     - bundle exec rake litmus:acceptance:parallel

--- a/Gemfile
+++ b/Gemfile
@@ -23,9 +23,12 @@ group :test do
 end
 
 group :acceptance do
+  # Litmus has dependencies which require Ruby 2.5 (Puppet 6) or above.
   if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.5.0')
-    # Litmus has dependencies which require Ruby 2.5 (Puppet 6) or above.
-    gem 'puppet_litmus', '~> 0.11', '>= 0.11.1'
+    # Until https://github.com/puppetlabs/puppet_litmus/pull/248 is merged we need to use the source of the
+    # of the PR.  Not the greatest and prone to error, but without it, all litmus based testing is broken.
+    # This can be reverted once this PR is merged and Litmus is released with this fix.
+    gem 'puppet_litmus', git: 'https://github.com/michaeltlombardi/puppet_litmus', ref: 'maint/master/fix-upload-file'
     gem 'net-ssh', '~> 5.2'
   end
 end


### PR DESCRIPTION
Currently the litmus based testing is broken due to bugs in both Litmus and
Bolt.  This commit modifies the acceptance testing to:

* Use a fixed fork of Litmus to enable the instal_modules_from_directory rake
  task
* Monkey patches Bolt to be able to used due to Bolt Issue 1614

These parts can be reverted once their related PRs are merged and released.