### PR TITLE
(maint) Do not use git for Gemspec files

### DIFF
--- a/puppet-strings.gemspec
+++ b/puppet-strings.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     'LICENSE',
     'README.md',
   ]
-  s.files = `git ls-files`.split("\n") - Dir['.*', '*.gemspec']
+  s.files = Dir['CHANGELOG.md', 'README.md', 'LICENSE', 'lib/**/*', 'exe/**/*']
 
   s.add_runtime_dependency 'yard', '~> 0.9.5'
   s.add_runtime_dependency 'rgen'


### PR DESCRIPTION
Previously the gemspec was using 'git ls-file' to retrieve the file list for
the gem, however this is problematic during development as untracked files are
not added, which can then cause an incomplete gem tarball to used during the
acceptance tests, which cause false negative test results.

This commit updates the Gemspec to use the more common Dir[..] method as used in
the PDK.