### PR TITLE
Handle function return tags without a type

### DIFF
--- a/lib/puppet-strings/yard/handlers/puppet/function_handler.rb
+++ b/lib/puppet-strings/yard/handlers/puppet/function_handler.rb
@@ -37,7 +37,7 @@ class PuppetStrings::Yard::Handlers::Puppet::FunctionHandler < PuppetStrings::Ya
   def add_return_tag(object, type=nil)
     tag = object.tag(:return)
     if tag
-      if (type && tag.types.first) && (type != tag.types.first)
+      if (type && tag.types && tag.types.first) && (type != tag.types.first)
         log.warn "Documented return type does not match return type in function definition near #{statement.file}:#{statement.line}."
       end
 

--- a/spec/fixtures/puppet/function_with_return.pp
+++ b/spec/fixtures/puppet/function_with_return.pp
@@ -1,0 +1,4 @@
+# @summary A simple Puppet function.
+# @return The answer to all your questions
+function func() >> Integer[42,42] {
+}


### PR DESCRIPTION
Puppet functions can specify a return type. In this case, there's no need to specify a type in the tag. Previously it tag.types was nil and thus calling nil.first.