### PR TITLE
Fix ERB failure - parameters without descriptions

### DIFF
--- a/lib/puppet-strings/markdown/base.rb
+++ b/lib/puppet-strings/markdown/base.rb
@@ -179,8 +179,12 @@ module PuppetStrings::Markdown
 
     # @return [String] full markdown rendering of a component
     def render(template)
-      file = File.join(File.dirname(__FILE__),"templates/#{template}")
-      ERB.new(File.read(file), nil, '-').result(binding)
+      begin
+        file = File.join(File.dirname(__FILE__),"templates/#{template}")
+        ERB.new(File.read(file), nil, '-').result(binding)
+      rescue => e
+        fail "Processing #{@registry[:file]}:#{@registry[:line]} with #{file} => #{e}"
+      end
     end
 
     private

--- a/lib/puppet-strings/markdown/base.rb
+++ b/lib/puppet-strings/markdown/base.rb
@@ -182,7 +182,7 @@ module PuppetStrings::Markdown
       begin
         file = File.join(File.dirname(__FILE__),"templates/#{template}")
         ERB.new(File.read(file), nil, '-').result(binding)
-      rescue => e
+      rescue StandardError => e
         fail "Processing #{@registry[:file]}:#{@registry[:line]} with #{file} => #{e}"
       end
     end

--- a/lib/puppet-strings/markdown/templates/resource_type.erb
+++ b/lib/puppet-strings/markdown/templates/resource_type.erb
@@ -120,7 +120,9 @@ Aliases: `<%= param[:aliases].to_s.delete('{').delete('}') %>`
 Data type: `<%= param[:data_type] %>`<%= "\n_\*this data type contains a regex that may not be accurately reflected in generated documentation_" if regex_in_data_type?(param[:data_type]) %>
 
 <% end -%>
+<% if param[:description] -%>
 <%= word_wrap(param[:description]) %>
+<% end -%>
 
 <% if options_for_param(param[:name]) -%>
 Options:


### PR DESCRIPTION
* The resource_type ERB file would fail on parameters without
  descriptions. These are a warning but should not cause a hard failure
* Added a log message to help isolate the file where issues are
  occurring