### PR TITLE
Handle a missing description gracefully

### DIFF
--- a/lib/puppet-strings/markdown/base.rb
+++ b/lib/puppet-strings/markdown/base.rb
@@ -172,6 +172,8 @@ module PuppetStrings::Markdown
     end
 
     def word_wrap(text, line_width: 120, break_sequence: "\n")
+      return unless text
+
       text.split("\n").collect! do |line|
         line.length > line_width ? line.gsub(/(.{1,#{line_width}})(\s+|$)/, "\\1#{break_sequence}").strip : line
       end * break_sequence


### PR DESCRIPTION
b5da040babf4bdbbcfd9bfabdb210041ccfa8ce3 introduced word_wrap which
assumes text is a string. However, this is not true and not every
resource type has a description.