### PR TITLE
Do not fail in case return tag has no type specified

### DIFF
--- a/lib/puppet-strings/yard/handlers/puppet/function_handler.rb
+++ b/lib/puppet-strings/yard/handlers/puppet/function_handler.rb
@@ -39,7 +39,7 @@ class PuppetStrings::Yard::Handlers::Puppet::FunctionHandler < PuppetStrings::Ya
   def add_return_tag(object, type=nil)
     tag = object.tag(:return)
     if tag
-      if (type && tag.types.first) && (type != tag.types.first)
+      if (type && tag.types && tag.types.first) && (type != tag.types.first)
         log.warn "Documented return type does not match return type in function definition near #{statement.file}:#{statement.line}."
       end
 

--- a/spec/unit/puppet-strings/yard/handlers/puppet/function_handler_spec.rb
+++ b/spec/unit/puppet-strings/yard/handlers/puppet/function_handler_spec.rb
@@ -256,6 +256,29 @@ function foo() >> Struct[{'a' => Integer[1, 10]}] {
     end
   end
 
+  describe 'parsing a function with return tag without type', if: TEST_FUNCTION_RETURN_TYPE do
+    let(:source) { <<-SOURCE
+# A simple foo function.
+# @return This is something.
+function foo() >> Struct[{'a' => Integer[1, 10]}] {
+  notice 'hello world'
+}
+    SOURCE
+    }
+
+    it 'should get the return type from the function definition' do
+      expect{ subject }.to output('').to_stdout_from_any_process
+      expect(subject.size).to eq(1)
+      object = subject.first
+      expect(object).to be_a(PuppetStrings::Yard::CodeObjects::Function)
+      tags = object.docstring.tags(:return)
+      expect(tags.size).to eq(1)
+      expect(tags[0].tag_name).to eq('return')
+      expect(tags[0].text).to eq('This is something.')
+      expect(tags[0].types).to eq(["Struct[{'a' => Integer[1, 10]}]"])
+    end
+  end
+
   describe 'parsing a function without a return tag or return type in the function definition' do
     let(:source) { <<-SOURCE
 # A simple foo function.


### PR DESCRIPTION
Currently puppet-strings fails if function documentation tag `return` has no type specified with "NoMethodError: undefined method `first' for nil:NilClass", so you either have no return tag or have to duplicate function return type in return tag.
This PR allows you to omit specifying return type.