### PR TITLE
Implement JSON Schema generation for lookup data

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,16 @@ gem install puppet-strings
 
 ## Generating documentation with Puppet Strings
 
-By default, Puppet Strings outputs documentation as HTML, or you can specify JSON or Markdown output instead.
+By default, Puppet Strings outputs documentation as HTML, or you can specify JSON or Markdown output instead. You can also specify [JSON Schema](https://json-schema.org/) format to produce a JSON
+Schema document.
 
 Strings generates reference documentation based on the code and Strings code comments in all Puppet and Ruby source files under the `./manifests/`, `./functions/`, `./lib/`, `./types/`, and `./tasks/` directories.
 
 Strings outputs HTML of the reference information and the module README to the module's `./doc/` directory. This output can be rendered in any browser.
 
 JSON and Markdown output include the reference documentation only. Strings sends JSON output to either STDOUT or to a file. Markdown output is written to a REFERENCE.md file in the module's main directory.
+
+JSON Schema output includes only class parameter documentation to support validation of keys specified for Automatic Parameter Lookup. It also includes documentation for any data type aliases, as those may be referenced as data types in the class parameters. The JSON Schema is generated with VSCode extensions to support Markdown formatting in the hover information.
 
 See the [Puppet Strings documentation](https://puppet.com/docs/puppet/latest/puppet_strings.html) for complete instructions for generating documentation with Strings. For code comment style guidelines and examples, see the [Puppet Strings style guide](https://puppet.com/docs/puppet/5.5/puppet_strings_style.html).
 
@@ -146,4 +149,3 @@ Bug fixes and ongoing development will occur in minor releases for the current m
 [contributing]: https://github.com/puppetlabs/puppet-strings/blob/main/CONTRIBUTING.md
 [committers]: https://github.com/puppetlabs/puppet-strings/blob/main/COMMITTERS.md
 [Puppet community Slack]: https://slack.puppet.com
-

--- a/lib/puppet-strings.rb
+++ b/lib/puppet-strings.rb
@@ -35,8 +35,8 @@ module PuppetStrings
     args << "-m#{options[:markup] || 'markdown'}"
 
     file = nil
-    if options[:json] || options[:markdown]
-      file = if options[:json]
+    if options[:json] || options[:markdown] || options[:jsonschema]
+      file = if options[:json] || options[:jsonschema]
                options[:path]
              elsif options[:markdown]
                options[:path] || "REFERENCE.md"
@@ -53,6 +53,10 @@ module PuppetStrings
 
     # Run YARD
     YARD::CLI::Yardoc.run(*args)
+
+    if options[:jsonschema]
+      render_jsonschema(file)
+    end
 
     # If outputting JSON, render the output
     if options[:json] && !options[:describe]
@@ -76,6 +80,11 @@ module PuppetStrings
   def self.render_json(path)
     require 'puppet-strings/json'
     PuppetStrings::Json.render(path)
+  end
+
+  def self.render_jsonschema(path)
+    require 'puppet-strings/json_schema'
+    PuppetStrings::JsonSchema.render(path)
   end
 
   def self.render_markdown(path)

--- a/lib/puppet-strings/json_schema.rb
+++ b/lib/puppet-strings/json_schema.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'deep_merge'
+require 'puppet_pal'
+
+require_relative 'json_schema/p_types'
+
+# The module for JSON related functionality.
+module PuppetStrings::JsonSchema
+  # Renders the current YARD registry pertinent to Lookup data as
+  # [JSON Schema](https://json-schema.org/) format to the given file
+  # (or STDOUT if nil).
+  #
+  # @param [String] file The path to the output file to render the registry to. If nil, output will be to STDOUT.
+  # @return [void]
+  def self.render(file = nil, code_string: nil)
+    document = {
+      :$schema => 'https://json-schema.org/draft/2020-12/schema#',
+      type: 'object',
+      additionalProperties: true,
+    }
+
+    type_aliases = {}
+    YARD::Registry.all(:puppet_data_type_alias).sort_by!(&:name).each do |data_type_alias|
+      type_aliases.merge!(data_type_alias.to_schema)
+    end
+
+    properties = {}
+    YARD::Registry.all(:puppet_class).sort_by!(&:name).each do |cls|
+      properties.merge!(cls.to_schema)
+    end
+
+    ptypes = PuppetStrings::JsonSchema::PTypes
+
+    ptypes.puppet_compiler(code_string: code_string) do |compiler|
+      properties.each do |name, prop|
+        next unless prop.key?(:_puppet_type)
+
+        parsed_type = prop.delete(:_puppet_type)
+        puppet_type = compiler.type(parsed_type)
+        schema_type = ptypes.ptype_to_schema(puppet_type)
+        prop.merge!(schema_type)
+      end
+
+      type_aliases.each do |name, prop|
+        next unless prop.key?(:_puppet_type)
+
+        parsed_type = prop.delete(:_puppet_type)
+        puppet_type = compiler.type(parsed_type)
+        schema_type = ptypes.ptype_to_schema(puppet_type)
+        prop.deep_merge!(schema_type)
+      end
+    end
+
+    document[:properties] = properties
+    document[:data_type_aliases] = type_aliases
+
+    if file
+      File.open(file, 'w') do |f|
+        f.write(JSON.pretty_generate(document))
+        f.write("\n")
+      end
+    else
+      puts JSON.pretty_generate(document)
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types.rb
+++ b/lib/puppet-strings/json_schema/p_types.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'puppet_pal'
+
+module PuppetStrings::JsonSchema
+  require_relative 'p_types/base'
+  require_relative 'p_types/p_any_type'
+  require_relative 'p_types/p_array_type'
+  require_relative 'p_types/p_boolean_type'
+  require_relative 'p_types/p_collection_type'
+  require_relative 'p_types/p_default_type'
+  require_relative 'p_types/p_enum_type'
+  require_relative 'p_types/p_float_type'
+  require_relative 'p_types/p_hash_type'
+  require_relative 'p_types/p_integer_type'
+  require_relative 'p_types/p_notundef_type'
+  require_relative 'p_types/p_numeric_type'
+  require_relative 'p_types/p_optional_type'
+  require_relative 'p_types/p_pattern_type'
+  require_relative 'p_types/p_regexp_type'
+  require_relative 'p_types/p_scalar_type'
+  require_relative 'p_types/p_string_type'
+  require_relative 'p_types/p_struct_type'
+  require_relative 'p_types/p_timestamp_type'
+  require_relative 'p_types/p_type_alias_type'
+  require_relative 'p_types/p_type_reference_type'
+  require_relative 'p_types/p_tuple_type'
+  require_relative 'p_types/p_undef_type'
+  require_relative 'p_types/p_variant_type'
+
+  module PTypes
+    def self.ptype_to_schema(puppet_type)
+      ptype = PuppetStrings::JsonSchema::PTypes::Base.new()
+      ptype.convert(puppet_type)
+    end
+
+    def self.valid_environment?
+      # Use the environment / environmentpath available as a result of running
+      # as a Puppet Face to provide a compiler environment which can resolve
+      # data type aliases for that environment:
+      @valid_env ||= Puppet::Pal.in_environment(
+        Puppet[:environment],
+        envpath: Puppet[:environmentpath],
+        facts: {}
+      ) { |pal| proc {} }
+    rescue ArgumentError
+      false
+    rescue Puppet::Settings::InterpolationError
+      false
+    else
+      true
+    end
+
+    def self.puppet_compiler(code_string: nil)
+      if valid_environment?
+        Puppet::Pal.in_environment(
+          Puppet[:environment],
+          envpath: Puppet[:environmentpath],
+          facts: {},
+        ) do |pal|
+          pal.with_catalog_compiler(code_string: code_string) do |compiler|
+            yield compiler
+          end
+        end
+      else
+        Puppet::Pal.in_tmp_environment('puppet_strings', facts: {}) do |pal|
+          pal.with_catalog_compiler(code_string: code_string) do |compiler|
+            yield compiler
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/base.rb
+++ b/lib/puppet-strings/json_schema/p_types/base.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module PuppetStrings::JsonSchema
+  module PTypes
+    class Base
+      def convert(type)
+        # PDataType is actually defined in terms of a data type alias. This
+        # short cuts right to any value, which for JSON/YAML data is a good fit
+        # for 'Data':
+        return {} if type.name == 'Data'
+
+        ptype = puppet_type(type)
+        begin
+          ptype_cls = Object.const_get("PuppetStrings::JsonSchema::PTypes::#{ptype}")
+        rescue NameError
+          {
+            :$comment => "Conversion for Puppet type #{ptype} is not implemented yet"
+          }
+        else
+          ptype_cls.new.emit(type)
+        end
+      end
+
+      def emit
+        raise 'Not implemented - you must implement this in the data type class'
+      end
+
+      def any_of(list)
+        {
+          anyOf: list
+        }
+      end
+
+      private
+
+      def ptype_short_name(clsname)
+        clsname.to_s.split('::')[-1]
+      end
+
+      def puppet_type(type)
+        raise "Not a Puppet data type, got #{type.class}" unless type.is_a?(Puppet::Pops::Types::PAnyType)
+
+        pname = ptype_short_name(type.class)
+      end
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_any_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_any_type.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PAnyType < Base
+    def emit(type)
+      {}
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_array_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_array_type.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PArrayType < Base
+    def emit(type)
+      st = {
+        type: 'array',
+      }
+
+      unless type.element_type.class == Puppet::Pops::Types::PAnyType
+        st[:items] = convert(type.element_type)
+      end
+      size = type.size_type
+      return st if size.nil?
+
+      st[:minItems] = size.from unless size.from.nil?
+      st[:maxItems] = size.to unless size.to.nil?
+      st
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_boolean_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_boolean_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PBooleanType < Base
+    def emit(type)
+      {
+        type: 'boolean'
+      }
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_collection_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_collection_type.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PCollectionType < Base
+    def emit(type)
+      {
+        anyOf: [
+          {
+            type: 'object',
+          },
+          {
+            type: 'array',
+          },
+        ]
+      }
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_default_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_default_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PDefaultType < Base
+    def emit(type)
+      # The default type is not representable in Hiera:
+      {}
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_enum_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_enum_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PEnumType < Base
+    def emit(type)
+      {
+        enum: type.values
+      }
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_float_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_float_type.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PFloatType < Base
+    def emit(type)
+      st = { type: 'number' }
+      st[:minimum] = type.from unless type.from.nil?
+      st[:maximum] = type.to unless type.to.nil?
+      st
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_hash_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_hash_type.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PHashType < Base
+    def emit(type)
+      st = { type: 'object' }
+
+      unless type.value_type.class == Puppet::Pops::Types::PAnyType
+        st[:additionalProperties] = convert(type.value_type)
+      end
+      size = type.size_type
+      return st if size.nil?
+
+      st[:minProperties] = size.from unless size.from.nil?
+      st[:maxProperties] = size.to unless size.to.nil?
+      st
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_integer_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_integer_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PIntegerType < PFloatType
+    def emit(type)
+      st = super(type)
+      st[:type] = 'integer'
+      st
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_notundef_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_notundef_type.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PNotUndefType < Base
+    def emit(type)
+      {
+        not: {
+          type: 'null'
+        }
+      }
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_numeric_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_numeric_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PNumericType < Base
+    def emit(type)
+      {
+        type: 'number'
+      }
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_optional_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_optional_type.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class POptionalType < Base
+    def emit(type)
+      any_of(
+        [
+          { type: 'null' },
+          convert(type.type),
+        ]
+      )
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_pattern_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_pattern_type.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'js_regex'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PPatternType < Base
+    def emit(type)
+      if type.patterns.size > 1
+        any_of(type.patterns.map { |r| emit_pattern(r) })
+      else
+        emit_pattern(type.patterns.first)
+      end
+    end
+
+    private
+
+    def emit_pattern(type)
+      st = { type: 'string' }
+
+      js = JsRegex.new(type.regexp)
+
+      unless js.warnings.empty?
+        st[:$comment] = "Unable to convert regex to Javascript type: #{js.warnings.join("\n")}"
+        return st
+      end
+
+      st[:pattern] = js.source
+      st
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_regexp_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_regexp_type.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PRegexpType < Base
+    def emit(type)
+      if type.pattern
+        {
+          const: type.pattern,
+        }
+      else
+        {
+          type: 'string',
+        }
+      end
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_scalar_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_scalar_type.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PScalarType < Base
+    def emit(type)
+      {
+        anyOf: [
+          {
+            type: 'number',
+          },
+          {
+            type: 'string',
+          },
+          {
+            type: 'boolean',
+          },
+        ]
+      }
+    end
+  end
+
+  class PScalarDataType < PScalarType
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_string_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_string_type.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PStringType < Base
+    def emit(type)
+      min = nil
+      max = nil
+
+      if (sizetype = type.size_type)
+        min = sizetype.from
+        max = sizetype.to
+      end
+
+      st = { type: 'string' }
+      st[:minLength] = min unless min.nil?
+      st[:maxLength] = max unless max.nil?
+      st
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_struct_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_struct_type.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PStructType < Base
+    def emit(type)
+      st = {
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      }
+
+      type.elements.each do |element|
+        r = process_struct_element(element)
+        st[:properties].merge!(r[:properties])
+        st[:required].concat(r[:required])
+      end
+
+      st
+    end
+
+    def process_struct_element(element)
+      key_type = element.key_type
+      required = false
+
+      key = if key_type.is_a?(Puppet::Pops::Types::POptionalType)
+              key_type.type.size_type_or_value.to_sym
+            else
+              required = true
+              key_type.size_type_or_value.to_sym
+            end
+
+      value = convert(element.value_type)
+
+      {
+        properties: {
+          key => value,
+        },
+        required: required ? [key] : []
+      }
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_timestamp_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_timestamp_type.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PTimestampType < Base
+    def emit(type)
+      {
+        anyOf: [
+          {
+            type: 'string',
+            format: 'date-time',
+          },
+          {
+            type: 'string',
+            format: 'date',
+          },
+        ],
+      }
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_tuple_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_tuple_type.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PTupleType < Base
+    def emit(type)
+      st = {
+        type: 'array',
+        prefixItems: type.types.map { |t| convert(t) },
+      }
+      size = type.size_type
+
+      st[:minItems] = size&.from || type.types.size
+      st[:maxItems] = size&.to || type.types.size
+
+      if size&.to && size.to > type.types.size
+        st[:items] = st[:prefixItems].last
+      end
+      st
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_type_alias_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_type_alias_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PTypeAliasType < Base
+    def emit(type)
+      {
+        :$ref => "#/data_type_aliases/#{type.name.downcase}"
+      }
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_type_reference_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_type_reference_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PTypeReferenceType < Base
+    def emit(type)
+      {
+        :$ref => "#/data_type_aliases/#{type.type_string.downcase}"
+      }
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_undef_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_undef_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PUndefType < Base
+    def emit(type)
+      {
+        type: 'null'
+      }
+    end
+  end
+end

--- a/lib/puppet-strings/json_schema/p_types/p_variant_type.rb
+++ b/lib/puppet-strings/json_schema/p_types/p_variant_type.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module PuppetStrings::JsonSchema::PTypes
+  class PVariantType < Base
+    def emit(type)
+      any_of(type.types.map { |t| convert(t) })
+    end
+  end
+end

--- a/lib/puppet-strings/yard/code_objects/data_type_alias.rb
+++ b/lib/puppet-strings/yard/code_objects/data_type_alias.rb
@@ -57,4 +57,35 @@ class PuppetStrings::Yard::CodeObjects::DataTypeAlias < PuppetStrings::Yard::Cod
     hash[:alias_of] = alias_of
     hash
   end
+
+  def to_schema
+    summary_tags = tags.select { |t| t.tag_name == 'summary' }
+    param_tags = tags.select { |t| t.tag_name == 'param' }
+
+    if summary_tags.empty?
+      title = name.to_s
+    else
+      title = summary_tags.first.text
+    end
+
+    doctext = (docstring || '').empty? ? title : (docstring || '')
+
+    hash = {
+      title: title,
+      description: doctext.gsub("\n", ' '),
+      markdownDescription: doctext,
+      _puppet_type: alias_of,
+      :$comment => alias_of,
+    }
+
+    props = {}
+    param_tags.each do |tag|
+      props[tag.name] = {
+        description: tag.text,
+        markdownDescription: tag.text,
+      }
+    end
+    hash[:properties] = props unless props.empty?
+    { name.downcase => hash }
+  end
 end

--- a/lib/puppet/face/strings.rb
+++ b/lib/puppet/face/strings.rb
@@ -10,7 +10,7 @@ Puppet::Face.define(:strings, '0.0.1') do
     default
 
     option '--format OUTPUT_FORMAT' do
-      summary 'Designate output format, JSON or markdown.'
+      summary 'Designate output format, JSON, JSONSchema or markdown.'
     end
     option '--out PATH' do
       summary 'Write selected format to PATH. If no path is designated, strings prints to STDOUT.'
@@ -117,7 +117,7 @@ Puppet::Face.define(:strings, '0.0.1') do
       options[:describe] = true
       options[:stdout] = true
       options[:format] = 'json'
-      
+
       if args.length > 1
         if options[:list]
           warn "WARNING: ignoring types when listing all types."
@@ -185,8 +185,10 @@ Puppet::Face.define(:strings, '0.0.1') do
         elsif format.casecmp('json').zero? || options[:emit_json] || options[:emit_json_stdout]
           generate_options[:json] = true
           generate_options[:path] ||= options[:emit_json] if options[:emit_json]
+        elsif format.casecmp('jsonschema').zero?
+          generate_options[:jsonschema] = true
         else
-          raise RuntimeError, "Invalid format #{options[:format]}. Please select 'json' or 'markdown'."
+          raise RuntimeError, "Invalid format #{options[:format]}. Please select 'json', 'jsonschema', or 'markdown'."
         end
       elsif options[:emit_json] || options[:emit_json_stdout]
         generate_options[:json] = true

--- a/puppet-strings.gemspec
+++ b/puppet-strings.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'yard', '~> 0.9.5'
   s.add_runtime_dependency 'rgen'
   s.requirements << 'puppet, >= 5.0.0'
+  s.add_dependency 'js_regex', '~> 3.7'
 end

--- a/spec/fixtures/environments/testenv/environment.conf
+++ b/spec/fixtures/environments/testenv/environment.conf
@@ -1,0 +1,1 @@
+modulepath = modules

--- a/spec/fixtures/environments/testenv/modules/testmod/manifests/init.pp
+++ b/spec/fixtures/environments/testenv/modules/testmod/manifests/init.pp
@@ -1,0 +1,8 @@
+# Testmod
+#
+# @param mystr
+#   Test param
+#
+class testmod (
+  String[1] $mystr,
+) {}

--- a/spec/unit/puppet-strings/jsonschema/ptypes_spec.rb
+++ b/spec/unit/puppet-strings/jsonschema/ptypes_spec.rb
@@ -1,0 +1,487 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'puppet-strings/json_schema/p_types'
+require 'puppet/test/test_helper'
+
+Puppet::Test::TestHelper.initialize
+
+describe PuppetStrings::JsonSchema::PTypes do
+  before(:all) do
+    Puppet::Test::TestHelper.before_all_tests()
+  end
+
+  after(:all) do
+    Puppet::Test::TestHelper.after_all_tests()
+  end
+
+  before(:each) do
+    Puppet::Test::TestHelper.before_each_test()
+  end
+
+  after(:each) do
+    Puppet::Test::TestHelper.after_each_test()
+  end
+
+  context '#valid_environment?' do
+    subject { described_class.valid_environment? }
+
+    after(:each) do
+      PuppetStrings::JsonSchema::PTypes.instance_variable_set(:@valid_env, nil)
+    end
+
+    context 'without an environment' do
+      before(:each) do
+        Puppet[:environmentpath] = '/dev/null'
+        Puppet.initialize_settings
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'with an environment' do
+      before(:each) do
+        path = File.expand_path(File.join(__dir__, '..', '..', '..', 'fixtures', 'environments'))
+        Puppet[:environmentpath] = path
+        Puppet[:environment] = 'testenv'
+        Puppet.initialize_settings
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when receiving an interpolation error' do
+      before(:each) do
+        path = File.expand_path(File.join(__dir__, '..', '..', '..', 'fixtures', 'environments'))
+        Puppet[:environmentpath] = path
+        Puppet[:environment] = 'testenv'
+        Puppet.initialize_settings
+        Puppet::Pal.stubs(:in_environment).with(any_parameters).raises(Puppet::Settings::InterpolationError)
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
+  context '#puppet_compiler' do
+    context 'without a valid environment' do
+      before do
+        described_class.stubs(:valid_environment?).returns(false)
+      end
+
+      it { expect { |b| described_class.puppet_compiler(&b) }.to yield_with_args(Puppet::Pal::CatalogCompiler) }
+    end
+
+    context 'with a valid environment' do
+      before do
+        described_class.stubs(:valid_environment?).returns(true)
+      end
+
+      it { expect { |b| described_class.puppet_compiler(&b) }.to yield_with_args(Puppet::Pal::CatalogCompiler) }
+    end
+  end
+
+  context 'Base#emit' do
+    it { expect { described_class::Base.new.emit }.to raise_error(StandardError) }
+  end
+
+  context '#ptype_to_schema' do
+    let(:code) { nil }
+
+    subject(:ptype) do |example|
+      type = described_class.puppet_compiler(code_string: code) do |c|
+        c.type(example.description)
+      end
+      described_class.ptype_to_schema(type)
+    end
+
+    context 'when conversion is not implemented' do
+      before do
+        Object.stubs(:const_get).with("PuppetStrings::JsonSchema::PTypes::PStringType").raises(NameError)
+      end
+
+      it 'String' do
+        is_expected.to eq(:$comment => 'Conversion for Puppet type PStringType is not implemented yet')
+      end
+    end
+
+    context 'Any' do
+      it 'Any' do
+        is_expected.to eq({})
+      end
+    end
+
+    context 'Array' do
+      it 'Array' do
+        is_expected.to eq(
+          type: 'array'
+        )
+      end
+
+      it 'Array[String]' do
+        is_expected.to eq(
+          type: 'array',
+          items: {type: 'string'},
+        )
+      end
+
+      it 'Array[Integer, 2, 3]' do
+        is_expected.to eq(
+          type: 'array',
+          items: {type: 'integer'},
+          minItems: 2,
+          maxItems: 3,
+        )
+      end
+    end
+
+    context 'Boolean' do
+      it 'Boolean' do
+        is_expected.to eq(type: 'boolean')
+      end
+    end
+
+    context 'Collection' do
+      it 'Collection' do
+        is_expected.to eq({anyOf: [{type: 'object'}, {type: 'array'}]})
+      end
+    end
+
+    context 'Data' do
+      it 'Data' do
+        is_expected.to eq({})
+      end
+    end
+
+    context 'Default' do
+      it 'Default' do
+        is_expected.to eq({})
+      end
+    end
+
+    context 'Enum' do
+      it 'Enum[red, green, blue]' do
+        is_expected.to eq({enum: ['blue', 'green', 'red']})
+      end
+    end
+
+    context 'Float' do
+      it 'Float' do
+        is_expected.to eq(type: 'number')
+      end
+
+      it 'Float[1.2,5.3]' do
+        is_expected.to eq(type: 'number', minimum: 1.2, maximum: 5.3)
+      end
+
+      it 'Float[default,5.2]' do
+        is_expected.to eq(type: 'number', maximum: 5.2)
+      end
+
+      it 'Float[2.3]' do
+        is_expected.to eq(type: 'number', minimum: 2.3)
+      end
+    end
+
+    context 'Hash' do
+      it 'Hash' do
+        is_expected.to eq(type: 'object')
+      end
+
+      it 'Hash[String, String]' do
+        is_expected.to eq(type: 'object', additionalProperties: { type: 'string' })
+      end
+
+      it 'Hash[Scalar, Integer, 1, 4]' do
+        is_expected.to eq(
+          type: 'object',
+          additionalProperties: { type: 'integer' },
+          minProperties: 1,
+          maxProperties: 4,
+        )
+      end
+    end
+
+    context 'Integer' do
+      it 'Integer' do
+        is_expected.to eq(type: 'integer')
+      end
+
+      it 'Integer[1,5]' do
+        is_expected.to eq(type: 'integer', minimum: 1, maximum: 5)
+      end
+
+      it 'Integer[default,5]' do
+        is_expected.to eq(type: 'integer', maximum: 5)
+      end
+
+      it 'Integer[2]' do
+        is_expected.to eq(type: 'integer', minimum: 2)
+      end
+    end
+
+    context 'NotUndef' do
+      it 'NotUndef' do
+        is_expected.to eq({not: { type: 'null' } })
+      end
+    end
+
+    context 'Numeric' do
+      it 'Numeric' do
+        is_expected.to eq({ type: 'number' })
+      end
+    end
+
+    context 'Optional' do
+      it 'Optional[String]' do
+        is_expected.to eq({anyOf: [{type: 'null'}, {type: 'string'}]})
+      end
+    end
+
+    context 'Pattern' do
+      it 'Pattern[/^foobar$/]' do
+        is_expected.to eq(type: 'string', pattern: '^foobar$')
+      end
+
+      it 'Pattern[/^foobar$/, /^[a-z][0-9]+/]' do
+        is_expected.to eq(
+          {
+            anyOf: [
+              {
+                type: 'string',
+                pattern: '^foobar$',
+              },
+              {
+                type: 'string',
+                pattern: '^[a-z][0-9]+',
+              },
+            ],
+          },
+        )
+      end
+
+      it 'Pattern[/(?<!fizz)buzz/]' do
+        is_expected.to include(:$comment => %r{^Unable to convert regex to Javascript})
+      end
+
+      it 'Pattern[/(?i:foo)/]' do
+        is_expected.to eq(
+          type: 'string',
+          pattern: '(?:[fF][oO][oO])',
+        )
+      end
+
+      it 'Pattern[/(?x:foo  bar)/]' do
+        is_expected.to eq(
+          type: 'string',
+          pattern: '(?:foobar)',
+        )
+      end
+    end
+
+    context 'Regexp' do
+      it 'Regexp[/^[a-z][a-z0-9]+/]' do
+        is_expected.to eq(const: '^[a-z][a-z0-9]+')
+      end
+
+      it 'Regexp' do
+        is_expected.to eq({type: 'string'})
+      end
+    end
+
+    context 'Scalar' do
+      it 'Scalar' do
+        is_expected.to eq({anyOf: [{type: 'number'}, {type: 'string'}, {type: 'boolean'}]})
+      end
+
+      it 'ScalarData' do
+        is_expected.to eq({anyOf: [{type: 'number'}, {type: 'string'}, {type: 'boolean'}]})
+      end
+    end
+
+    context 'Strings' do
+      it 'String' do
+        is_expected.to eq(type: 'string')
+      end
+
+      it 'String[1,5]' do
+        is_expected.to eq(type: 'string', maxLength: 5, minLength: 1)
+      end
+
+      it 'String[default,5]' do
+        is_expected.to eq(type: 'string', minLength: 0, maxLength: 5)
+      end
+
+      it 'String[1]' do
+        is_expected.to eq(type: 'string', minLength: 1)
+      end
+    end
+
+    context 'Struct' do
+      it 'Struct[{foo => String}]' do
+        is_expected.to eq(
+          {
+            type: 'object',
+            properties: {
+              foo: {
+                type: 'string',
+              }
+            },
+            required: [:foo],
+            additionalProperties: false,
+          }
+        )
+      end
+
+      it 'Struct[{foo => String, bar => Integer}]' do
+        is_expected.to eq(
+          {
+            type: 'object',
+            properties: {
+              foo: {
+                type: 'string',
+              },
+              bar: {
+                type: 'integer',
+              }
+            },
+            required: [:foo, :bar],
+            additionalProperties: false,
+          }
+        )
+      end
+
+      it 'Struct[{foo => String, Optional[bar] => Integer}]' do
+        is_expected.to eq(
+          {
+            type: 'object',
+            properties: {
+              foo: {
+                type: 'string',
+              },
+              bar: {
+                type: 'integer',
+              }
+            },
+            required: [:foo],
+            additionalProperties: false,
+          }
+        )
+      end
+
+      it 'Struct[{foo => String, bar => Optional[Integer]}]' do
+        is_expected.to eq(
+          {
+            type: 'object',
+            properties: {
+              foo: {
+                type: 'string',
+              },
+              bar: {
+                anyOf: [
+                  {
+                    type: 'null',
+                  },
+                  {
+                    type: 'integer',
+                  },
+                ]
+              }
+            },
+            required: [:foo],
+            additionalProperties: false,
+          }
+        )
+      end
+    end
+
+    context 'Timestamp' do
+      it 'Timestamp' do
+        is_expected.to eq(
+          {
+            anyOf: [
+              {
+                type: 'string',
+                format: 'date-time',
+              },
+              {
+                type: 'string',
+                format: 'date',
+              },
+            ],
+          }
+        )
+      end
+    end
+
+    context 'Tuple' do
+      it 'Tuple[String, Integer]' do
+        is_expected.to eq(
+          type: 'array',
+          prefixItems: [
+            { type: 'string' },
+            { type: 'integer' },
+          ],
+          minItems: 2,
+          maxItems: 2,
+        )
+      end
+
+      it 'Tuple[String, Integer, 1]' do
+        is_expected.to eq(
+          type: 'array',
+          prefixItems: [
+            { type: 'string' },
+            { type: 'integer' },
+          ],
+          minItems: 1,
+          maxItems: 2,
+        )
+      end
+
+      it 'Tuple[String, Integer, 1, 4]' do
+        is_expected.to eq(
+          type: 'array',
+          prefixItems: [
+            { type: 'string' },
+            { type: 'integer' },
+          ],
+          items: { type: 'integer' },
+          minItems: 1,
+          maxItems: 4,
+        )
+      end
+    end
+
+    context 'TypeAlias' do
+      let(:code) { 'type Foo = Variant[String[1,2], Integer[0,4]]' }
+      it 'Foo' do
+        is_expected.to eq(
+          {
+            :$ref => '#/data_type_aliases/foo'
+          }
+        )
+      end
+    end
+
+    context 'Undef' do
+      it 'Undef' do
+        is_expected.to eq({type: 'null'})
+      end
+    end
+
+    context 'Variant' do
+      it 'Variant[String, Integer]' do
+        is_expected.to eq(
+          {
+            anyOf: [
+              { type: 'string' },
+              { type: 'integer' },
+            ]
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/puppet-strings/jsonschema_spec.rb
+++ b/spec/unit/puppet-strings/jsonschema_spec.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'puppet-strings/json_schema'
+require 'tempfile'
+require 'puppet/test/test_helper'
+
+Puppet::Test::TestHelper.initialize
+
+describe PuppetStrings::JsonSchema do
+  before(:all) do
+    Puppet::Test::TestHelper.before_all_tests()
+  end
+
+  after(:all) do
+    Puppet::Test::TestHelper.after_all_tests()
+  end
+
+  before(:each) do
+    Puppet::Test::TestHelper.before_each_test()
+  end
+
+  after(:each) do
+    Puppet::Test::TestHelper.after_each_test()
+  end
+
+  before :each do
+    # Populate the YARD registry with Puppet source
+    YARD::Parser::SourceParser.parse_string(code, :puppet)
+  end
+
+  let(:code) do
+    <<~CODE
+    # This is a simple struct.
+    # @summary Quick summary.
+    # @param one The first.
+    # @param two The second.
+    type Foobar::MyStruct = Struct[{'one' => String, 'two' => Optional[String]}]
+
+    # Simple data type alias
+    type Foobar::Simple = String[1,2]
+
+    # A simple class.
+    # @todo Do a thing
+    # @note Some note
+    # @param param1 First param.
+    # @param param2 Second param.
+    # @param param3 Third param.
+    # @param param4 Fourth param.
+    class klass(Integer $param1, $param2, Variant[Foobar::Simple] $param3 = hi, Foobar::MyStruct $param4) {
+    }
+    CODE
+  end
+
+  RSpec.shared_examples "correct JSON schema" do
+    subject(:output) { JSON.parse(json_output) }
+
+    it 'should include the $schema key' do
+      is_expected.to include('$schema' => 'https://json-schema.org/draft/2020-12/schema#')
+    end
+
+    it 'should be an object at the top level' do
+      is_expected.to include('type' => 'object')
+    end
+
+    it 'should allow additional properties' do
+      is_expected.to include('additionalProperties' => true)
+    end
+
+    it 'should have data type aliases' do
+      is_expected.to include('data_type_aliases')
+    end
+
+    context 'data type alias Foobar::MyStruct' do
+      subject { super().dig('data_type_aliases', 'foobar::mystruct') }
+
+      it 'should have Foobar::MyStruct' do
+        is_expected.to be_a(Hash)
+      end
+
+      it 'should have $comment' do
+        is_expected.to include('$comment' => 'Struct[{\'one\' => String, \'two\' => Optional[String]}]')
+      end
+
+      it 'should have type' do
+        is_expected.to include('type' => 'object')
+      end
+
+      it 'should have additionalProperties' do
+        is_expected.to include('additionalProperties' => false)
+      end
+
+      it 'should have description' do
+        is_expected.to include('description' => 'This is a simple struct.')
+      end
+
+      it 'should have markdowndescription' do
+        is_expected.to include('markdownDescription' => 'This is a simple struct.')
+      end
+
+      it 'should have title' do
+        is_expected.to include('title' => 'Quick summary.')
+      end
+
+      it 'should have property one' do
+        is_expected.to include(
+          'properties' => include(
+            'one' => {
+              'type' => 'string'
+            }
+          )
+        )
+      end
+
+      it 'should have property two' do
+        is_expected.to include(
+          'properties' => include(
+            'two' => {
+              'anyOf' => [
+                { 'type' => 'null' },
+                { 'type' => 'string' },
+              ]
+            }
+          )
+        )
+      end
+
+      it 'should have required' do
+        is_expected.to include('required' => ['one'])
+      end
+    end
+
+    context 'with klass::param1' do
+      subject { super().dig('properties', 'klass::param1') }
+
+      it 'should have klass::param1' do
+        is_expected.to be_a(Hash)
+      end
+
+      it 'should have $comment' do
+        is_expected.to include('$comment' => 'Puppet Data type: "Integer"')
+      end
+
+      it 'should have description' do
+        is_expected.to include('description' => 'First param.')
+      end
+
+      it 'should have markdownDescription' do
+        is_expected.to include('markdownDescription' => "`[Integer]`\n\nFirst param.\n\n")
+      end
+
+      it 'should have type' do
+        is_expected.to include('type' => 'integer')
+      end
+    end
+
+    context 'with klass::param2' do
+      subject { super().dig('properties', 'klass::param2') }
+
+      it 'should have klass::param2' do
+        is_expected.to be_a(Hash)
+      end
+
+      it 'should have $comment' do
+        is_expected.to include('$comment' => 'Puppet Data type: "Any"')
+      end
+
+      it 'should have description' do
+        is_expected.to include('description' => 'Second param.')
+      end
+
+      it 'should have markdownDescription' do
+        is_expected.to include('markdownDescription' => "`[Any]`\n\nSecond param.\n\n")
+      end
+
+      it 'should not have type' do
+        is_expected.not_to include('type')
+      end
+    end
+
+    context 'with Foobar::Simple' do
+      subject { super().dig('data_type_aliases', 'foobar::simple') }
+
+      it 'should have foobar::simple' do
+        is_expected.to be_a(Hash)
+      end
+
+      it 'should have $comment' do
+        is_expected.to include('$comment' => 'String[1, 2]')
+      end
+
+      it 'should have description' do
+        is_expected.to include('description' => 'Simple data type alias')
+      end
+
+      it 'should have markdownDescription' do
+        is_expected.to include('markdownDescription' => 'Simple data type alias')
+      end
+
+      it 'should have type' do
+        is_expected.to include('type' => 'string')
+      end
+
+      it 'should have title' do
+        is_expected.to include('title' => 'Foobar::Simple')
+      end
+
+      it 'should have minLength' do
+        is_expected.to include('minLength' => 1)
+      end
+
+      it 'should have maxLength' do
+        is_expected.to include('maxLength' => 2)
+      end
+    end
+  end
+
+  describe 'rendering JSON to a file' do
+    let(:json_output) do
+      json_output = nil
+
+      Tempfile.open('json') do |file|
+        PuppetStrings::JsonSchema.render(file.path, code_string: code)
+
+        json_output = File.read(file.path)
+      end
+
+      json_output
+    end
+
+    include_examples "correct JSON schema"
+  end
+
+  describe 'rendering JSON to stdout' do
+    let(:json_output) { @json_output }
+
+    before(:each) do
+      output = StringIO.new
+
+      old_stdout = $stdout
+      $stdout = output
+
+      PuppetStrings::JsonSchema.render(nil, code_string: code)
+
+      $stdout = old_stdout
+
+      @json_output = output.string
+    end
+
+    include_examples "correct JSON schema"
+  end
+end


### PR DESCRIPTION
Generate https://json-schema.org data for all class parameters
to support validation of all Hiera automatic parameter lookup
based parameters based on the defined Puppet data types associated
with each parameter. The resulting schema also includes parameter
descriptions based on the documentation which can be displayed by
IDEs as users are working.

If run against a Puppet environment the resulting schema will
also have all data type aliases resolved and included in the
schema, with supporting documentation.