### PR TITLE
(FIXUP) Check for nil before injecting provider param into Types

### DIFF
--- a/lib/puppet-strings/yard/code_objects/type.rb
+++ b/lib/puppet-strings/yard/code_objects/type.rb
@@ -152,7 +152,7 @@ class PuppetStrings::Yard::CodeObjects::Type < PuppetStrings::Yard::CodeObjects:
     return @parameters if providers.empty?
 
     # return existing params if we have already added provider
-    return @parameters if @parameters.any? { |p| p.name == 'provider' }
+    return @parameters if @parameters&.any? { |p| p.name == 'provider' }
 
     provider_param = Parameter.new(
       'provider',
@@ -160,6 +160,7 @@ class PuppetStrings::Yard::CodeObjects::Type < PuppetStrings::Yard::CodeObjects:
       "to specify this --- Puppet will usually discover the appropriate provider for your platform."
     )
 
+    @parameters ||= []
     @parameters << provider_param
   end
 


### PR DESCRIPTION
cc @nkanderson 

See https://forge.puppet.com/modules/enterprisemodules/ora_install/5.12.3 for an example of a module that would trigger an error before.

Error triggered was:

```
$ bx puppet strings generate --format json /Users/jesse/tmp/enterprisemodules-ora_install-5.12.3/ --trace
Error: undefined method `any?' for nil:NilClass
/Users/jesse/src/puppet-strings/lib/puppet-strings/yard/code_objects/type.rb:155:in `parameters'
/Users/jesse/src/puppet-strings/lib/puppet-strings/yard/code_objects/type.rb:187:in `to_hash'
/Users/jesse/src/puppet-strings/lib/puppet-strings/json.rb:16:in `map!'
/Users/jesse/src/puppet-strings/lib/puppet-strings/json.rb:16:in `render'
/Users/jesse/src/puppet-strings/lib/puppet-strings.rb:78:in `render_json'
/Users/jesse/src/puppet-strings/lib/puppet-strings.rb:59:in `generate'
...
Error: Try 'puppet help strings generate' for usage
```