### PR TITLE
Fix undefined method `any?' for nil:NilClass error. Fixes #287

### DIFF
--- a/lib/puppet-strings/yard/code_objects/type.rb
+++ b/lib/puppet-strings/yard/code_objects/type.rb
@@ -148,6 +148,7 @@ class PuppetStrings::Yard::CodeObjects::Type < PuppetStrings::Yard::CodeObjects:
   end
 
   def parameters
+    @parameters ||= []  # guard agains not filled parameters
     # just return params if there are no providers
     return @parameters if providers.empty?
 


### PR DESCRIPTION
In some rare cases where no parameter is (yet) defined in the type, an error is thrown

```
Error: undefined method `any?' for nil:NilClass
```