### PR TITLE
add data type list when having only data type aliases (fixes #298)

### DIFF
--- a/lib/puppet-strings/yard/templates/default/layout/html/setup.rb
+++ b/lib/puppet-strings/yard/templates/default/layout/html/setup.rb
@@ -81,11 +81,6 @@ def create_menu_lists
       search_title: 'Puppet Classes'
     },
     {
-      type: 'puppet_data_type',
-      title: 'Data Types',
-      search_title: 'Data Types',
-    },
-    {
       type: 'puppet_defined_type',
       title: 'Defined Types',
       search_title: 'Defined Types',
@@ -128,6 +123,13 @@ def create_menu_lists
   ]
 
   menu_lists.delete_if { |e| YARD::Registry.all(e[:type].intern).empty? }
+
+  # This is a special group containing two types
+  menu_lists << {
+      type: 'puppet_data_type',
+      title: 'Data Types',
+      search_title: 'Data Types',
+  } if ! YARD::Registry.all(:puppet_data_type,:puppet_data_type_alias).empty?
 
   # We must always return at least one group, so always keep the files list
   menu_lists << {


### PR DESCRIPTION
Documentation containing data type aliases without any data types will not generate puppet_data_type_list.html and the right navigation iframe will contain 404 not found error when on Data Type Alias documentation page. Also the top navigation will be missing Data Types section.

This is caused by only puppet_data_type existence being checked when determining wether to generate the list, but the whole section is setup to contain both puppet_data_type and puppet_data_type_alias.