### PR TITLE
(#304) Fix double backticks in Markdown

### DIFF
--- a/lib/puppet-strings/markdown/base.rb
+++ b/lib/puppet-strings/markdown/base.rb
@@ -158,19 +158,6 @@ module PuppetStrings::Markdown
       clean_link(name)
     end
 
-    # Some return, default, or valid values need to be in backticks. Instead of fu in the handler or code_object, this just does the change on the front.
-    # @param value
-    #  any string
-    # @return [String] value or value in backticks if it is in a list
-    def value_string(value)
-      to_symbol = %w[undef true false]
-      if to_symbol.include? value
-        return "`#{value}`"
-      else
-        return value
-      end
-    end
-
     def private?
       @tags.any? { |tag| tag[:tag_name] == 'api' && tag[:text] == 'private' }
     end

--- a/lib/puppet-strings/markdown/templates/classes_and_defines.erb
+++ b/lib/puppet-strings/markdown/templates/classes_and_defines.erb
@@ -79,7 +79,7 @@ Options:
 
 <% end -%>
 <% if defaults && defaults[param[:name]] -%>
-Default value: `<%= value_string(defaults[param[:name]]) %>`
+Default value: `<%= defaults[param[:name]] %>`
 
 <% end -%>
 <% end -%>

--- a/lib/puppet-strings/markdown/templates/data_type.erb
+++ b/lib/puppet-strings/markdown/templates/data_type.erb
@@ -87,7 +87,7 @@ Options:
 
 <% end -%>
 <% if defaults && defaults[param[:name]] -%>
-Default value: `<%= value_string(defaults[param[:name]]) %>`
+Default value: `<%= defaults[param[:name]] %>`
 
 <% end -%>
 <% end -%>

--- a/lib/puppet-strings/markdown/templates/resource_type.erb
+++ b/lib/puppet-strings/markdown/templates/resource_type.erb
@@ -53,7 +53,7 @@ The following properties are available in the `<%= name %>` <%= @type %>.
 ##### `<%= prop[:name] %>`
 
 <% if prop[:values] -%>
-Valid values: `<%= prop[:values].map { |value| value_string(value) }.join('`, `') %>`
+Valid values: `<%= prop[:values].join('`, `') %>`
 
 <% end -%>
 <% if prop[:isnamevar] -%>
@@ -105,7 +105,7 @@ The following parameters are available in the `<%= name %>` <%= @type %>.
 ##### <a name="<%= param[:link] %>"></a>`<%= param[:name] %>`
 
 <% if param[:values] -%>
-Valid values: `<%= param[:values].map { |value| value_string(value) }.join('`, `') %>`
+Valid values: `<%= param[:values].join('`, `') %>`
 
 <% end -%>
 <% if param[:isnamevar] -%>
@@ -141,7 +141,7 @@ Options:
 
 <% end -%>
 <% if param[:default] -%>
-Default value: `<%= value_string(param[:default]) %>`
+Default value: `<%= param[:default] %>`
 
 <% end -%>
 <% if param[:required_features] -%>


### PR DESCRIPTION
Previously, some values in generated Markdown were wrapped in double backticks instead of single backticks. This removes the code that added the extra backticks.

See #304.