### PR TITLE
Fix acceptance tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
   repositories:
-    facts: 'git://github.com/puppetlabs/puppetlabs-facts.git'
-    provision: 'git://github.com/puppetlabs/provision.git'
-    puppet_agent: 'git://github.com/puppetlabs/puppetlabs-puppet_agent.git'
+    facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
+    provision: 'https://github.com/puppetlabs/provision.git'
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
   symlinks: []

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ Gemfile.lock
 /log/
 /*.gem
 /spec/acceptance/nodesets/
+/spec/fixtures/litmus_inventory.yaml
 /spec/fixtures/modules/
 /spec/fixtures/manifests/
 /inventory.yaml


### PR DESCRIPTION
Previously, acceptance tests were failing during the initial installation of fixtures:

> Cloning into 'spec/fixtures/modules/puppet_agent'...
> fatal: unable to connect to github.com:
> github.com\[0: 140.82.113.4]: errno=Connection timed out

This switches to using `https` URLs for the fixtures, which allows acceptance tests to proceed beyond that point.

---

I don’t normally use Docker, so it’s hard for me to tell what’s problem on my machine and what’s a problem with the acceptance testing setup. I’m getting errors while spinning up the CentOS container:

> Failure connecting to localhost:52595:
> {"target"=>"localhost:52595", "action"=>"command", "object"=>nil, "status"=>"failure", "value"=>{"_error"=>{"details"=>{}, "kind"=>"puppetlabs.tasks/connect-error", "msg"=>"Failed to connect to localhost:52595: pkeys are immutable on OpenSSL 3.0", "issue_code"=>"CONNECT_ERROR"}}}
