### PR TITLE
(#302) Fix warnings generated by ERB.new

### DIFF
--- a/lib/puppet-strings/markdown/base.rb
+++ b/lib/puppet-strings/markdown/base.rb
@@ -172,9 +172,9 @@ module PuppetStrings::Markdown
 
     # @return [String] full markdown rendering of a component
     def render(template)
+      file = File.join(File.dirname(__FILE__), 'templates', template)
       begin
-        file = File.join(File.dirname(__FILE__),"templates/#{template}")
-        ERB.new(File.read(file), nil, '-').result(binding)
+        PuppetStrings::Markdown.erb(file).result(binding)
       rescue StandardError => e
         fail "Processing #{@registry[:file]}:#{@registry[:line]} with #{file} => #{e}"
       end
@@ -197,6 +197,19 @@ module PuppetStrings::Markdown
     # @return [String] the anchor-safe string
     def clean_link(input)
       input.tr('^a-zA-Z0-9_-', '-')
+    end
+  end
+
+  # Helper function to load an ERB template.
+  #
+  # @param [String] path The full path to the template file.
+  # @return [ERB] Template
+  def self.erb(path)
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6.0')
+      ERB.new(File.read(path), trim_mode: '-')
+    else
+      # This outputs warnings in Ruby 2.6+.
+      ERB.new(File.read(path), nil, '-')
     end
   end
 end

--- a/lib/puppet-strings/markdown/table_of_contents.rb
+++ b/lib/puppet-strings/markdown/table_of_contents.rb
@@ -17,8 +17,8 @@ module PuppetStrings::Markdown
         group = toc
         priv = r.contains_private?
 
-        template = File.join(File.dirname(__FILE__),"templates/table_of_contents.erb")
-        final += ERB.new(File.read(template), nil, '-').result(binding)
+        template = File.join(File.dirname(__FILE__), 'templates/table_of_contents.erb')
+        final += PuppetStrings::Markdown.erb(template).result(binding)
       end
       final
     end


### PR DESCRIPTION
This has to special case Ruby <2.6.0 since those versions will interpret the keyword argument as a hash passed as the second argument.

Without this change running this code in Ruby 2.6+ will generate warnings about the parameters passed to `ERB.new`.

---

I’ve run the tests under Ruby 2.3.0 (with some dificulty; see #301) and this appears to work. At the very least it clears up all the warnings.