### PR TITLE
(#307) Always enable plan parsing

### DIFF
--- a/lib/puppet-strings/yard/parsers/puppet/parser.rb
+++ b/lib/puppet-strings/yard/parsers/puppet/parser.rb
@@ -24,13 +24,11 @@ class PuppetStrings::Yard::Parsers::Puppet::Parser < YARD::Parser::Base
   # @return [void]
   def parse
     begin
-      if @file.to_s.match?(%r{^plans|/plans/})
-        if Puppet::Util::Package.versioncmp(Puppet.version, '5.0.0') < 0
-          log.warn "Skipping #{@file}: Puppet Plans require Puppet 5 or greater."
-          return
-        end
-        Puppet[:tasks] = true if Puppet.settings.include?(:tasks)
+      if @file.to_s.match?(%r{^plans|/plans/}) && Puppet::Util::Package.versioncmp(Puppet.version, '5.0.0') < 0
+        log.warn "Skipping #{@file}: Puppet Plans require Puppet 5 or greater."
+        return
       end
+      Puppet[:tasks] = true if Puppet.settings.include?(:tasks)
       @statements ||= (@visitor.visit(::Puppet::Pops::Parser::Parser.new.parse_string(source)) || []).compact
     rescue ::Puppet::ParseError => e
       log.error "Failed to parse #{@file}: #{e.message}"

--- a/spec/unit/puppet-strings/json_spec.rb
+++ b/spec/unit/puppet-strings/json_spec.rb
@@ -7,7 +7,7 @@ require 'tempfile'
 describe PuppetStrings::Json do
   before :each do
     # Populate the YARD registry with both Puppet and Ruby source
-    YARD::Parser::SourceParser.parse_string(<<-SOURCE, :puppet)
+    expect(YARD::Parser::SourceParser.parse_string(<<-SOURCE, :puppet).enumerator.length).to eq(2)
 # A simple class.
 # @todo Do a thing
 # @note Some note
@@ -25,7 +25,7 @@ define dt(Integer $param1, $param2, String $param3 = hi) {
 }
     SOURCE
 
-    YARD::Parser::SourceParser.parse_string(<<-SOURCE, :puppet) if TEST_PUPPET_PLANS
+    expect(YARD::Parser::SourceParser.parse_string(<<-SOURCE, :puppet).enumerator.length).to eq(1) if TEST_PUPPET_PLANS
 # A simple plan.
 # @param param1 First param.
 # @param param2 Second param.
@@ -35,7 +35,7 @@ plan plann(String $param1, $param2, Integer $param3 = 1) {
     SOURCE
 
     # Only include Puppet functions for 4.1+
-    YARD::Parser::SourceParser.parse_string(<<-SOURCE, :puppet) if TEST_PUPPET_FUNCTIONS
+    expect(YARD::Parser::SourceParser.parse_string(<<-SOURCE, :puppet).enumerator.length).to eq(1) if TEST_PUPPET_FUNCTIONS
 # A simple function.
 # @param param1 First param.
 # @param param2 Second param.
@@ -46,7 +46,7 @@ function func(Integer $param1, $param2, String $param3 = hi) {
     SOURCE
 
     # Only include Puppet types for 5.0+
-    YARD::Parser::SourceParser.parse_string(<<-SOURCE, :ruby) if TEST_PUPPET_DATATYPES
+    expect(YARD::Parser::SourceParser.parse_string(<<-SOURCE, :ruby).enumerator.length).to eq(1) if TEST_PUPPET_DATATYPES
 # Basic Puppet Data Type in Ruby
 #
 # @param msg A message parameter
@@ -67,7 +67,7 @@ Puppet::DataTypes.create_type('RubyDataType') do
 end
 SOURCE
 
-    YARD::Parser::SourceParser.parse_string(<<-SOURCE, :json)
+    expect(YARD::Parser::SourceParser.parse_string(<<-SOURCE, :json).enumerator.length).to eq(1)
 {
   "description": "Allows you to backup your database to local file.",
   "input_method": "stdin",
@@ -92,7 +92,7 @@ SOURCE
 }
     SOURCE
 
-    YARD::Parser::SourceParser.parse_string(<<-SOURCE, :ruby)
+    expect(YARD::Parser::SourceParser.parse_string(<<-SOURCE, :ruby).enumerator.length).to eq(6)
 Puppet::Parser::Functions.newfunction(:func3x, doc: <<-DOC
 An example 3.x function.
 @param [String] first The first parameter.


### PR DESCRIPTION
This is an alternate to #311, which fixes this same problem in a different way. I like this solution better.

#### Catch parse failures in `PuppetStrings::Json` tests

Previously, the tests for `PuppetStrings::Json` (in json_spec.rb) parsed a variety of code samples and then queried YARD to test the results. Ifa sample failed to parse, an error might be outputted (see [issue #307][#307]), but no failure was registered by the testing harness.

This adds simple checks to verify that the parses actually succeed.

Unfortunately, one of the samples currently fails to parse, so this commit introduces a testing error. The subbsequent commit will fix it.

[#307]: https://github.com/puppetlabs/puppet-strings/issues/307

#### (#307) Fix plan parsing in JSON spec tests

Previously, the parsing code activated task support in Puppet when it detected that it was parsing a file in a plans/ directory. This casued the JSON spec test for plans to fail because it parsed a string, which naturally had no file name to check.

This turns on task support (and thus enables parsing plans) whenever the parser starts (assuming that task support is available).

This helps avoid surprises to future users who need to parse plans from ruby code, such as in tests.

#### Add a plan test to parser_spec.rb

Previously, none of the examples in parser_spec.rb included a Puppet plan. This adds a plan and verifies that it parses correctly.
