### PR TITLE
(#301) Update minimum Ruby version to 2.5.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require: rubocop-performance
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
   Exclude:
     # Ignore HTML related things
     - '**/*.erb'

--- a/Gemfile
+++ b/Gemfile
@@ -22,24 +22,21 @@ group :test do
   gem 'simplecov-console'
   gem 'rspec', '~> 3.1'
   gem 'json_spec', '~> 1.1', '>= 1.1.5'
-  gem 'mdl', '~> 0.8.0' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.4.0')
+  gem 'mdl'
 end
 
 group :acceptance do
-  # Litmus has dependencies which require Ruby 2.5 (Puppet 6) or above.
-  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.5.0')
-    gem 'puppet_litmus', '~> 0.18'
-    gem 'net-ssh', '~> 5.2'
-  end
+  gem 'puppet_litmus'
+  gem 'net-ssh'
 end
 
 group :development do
-  gem 'github_changelog_generator', '~> 1.15' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')
+  gem 'github_changelog_generator'
   gem 'pry'
   gem 'pry-byebug'
 end
 
-gem 'rubocop', '~> 0.81.0' # last release that supports Ruby 2.3.0
+gem 'rubocop', '~> 0.81.0' # Requires work to upgrade
 gem 'rubocop-rspec'
 gem 'rubocop-performance'
 

--- a/puppet-strings.gemspec
+++ b/puppet-strings.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email = 'info@puppet.com'
   s.homepage = 'https://github.com/puppetlabs/puppet-strings'
   s.description = s.summary
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.extra_rdoc_files = [
     'CHANGELOG.md',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,18 +1,15 @@
 # frozen_string_literal: true
 
 if ENV['COVERAGE'] == 'yes'
+  require 'codecov'
   require 'simplecov'
   require 'simplecov-console'
 
   SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,
     SimpleCov::Formatter::Console,
+    SimpleCov::Formatter::Codecov,
   ]
-
-  unless Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')
-    require 'codecov'
-    SimpleCov.formatters << SimpleCov::Formatter::Codecov
-  end
 
   SimpleCov.start do
     track_files 'lib/**/*.rb'
@@ -22,6 +19,7 @@ if ENV['COVERAGE'] == 'yes'
 end
 
 require 'mocha'
+require 'mdl'
 require 'rspec'
 require 'json_spec'
 require 'puppet/version'
@@ -54,15 +52,7 @@ RSpec.configure do |config|
   end
 end
 
-def mdl_available
-  @mdl_available ||= !Gem::Specification.select { |item| item.name.casecmp('mdl').zero? }.empty?
-end
-
 def lint_markdown(content)
-  return [] unless mdl_available
-
-  require 'mdl'
-
   # Load default mdl ruleset
   ruleset = MarkdownLint::RuleSet.new.tap { |r| r.load_default }
 

--- a/spec/unit/puppet-strings/markdown_spec.rb
+++ b/spec/unit/puppet-strings/markdown_spec.rb
@@ -46,7 +46,7 @@ describe PuppetStrings::Markdown do
   let(:output) { PuppetStrings::Markdown.generate }
 
   RSpec.shared_examples 'markdown lint checker' do |parameter|
-    it 'should not generate markdown lint errors from the rendered markdown', if: mdl_available do
+    it 'should not generate markdown lint errors from the rendered markdown' do
       expect(output).to have_no_markdown_lint_errors
     end
   end


### PR DESCRIPTION
Previously, the minimum Ruby version was 2.3.0, but it was dificult to get it working and some of the code had been updated to use features as new as 2.4.6.

This clears out code that checked for old Ruby versions, and removes some version constraints in Gemfile that were needed to work with Ruby 2.3.0.