### PR TITLE
(MAINT) Add release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: "Release"
+
+on:
+  workflow_dispatch:
+   inputs:
+    target:
+      description: "The target for the release. This can be a commit sha or a branch."
+      required: false
+      default: "main"
+
+jobs:
+  release:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_release.yml@main"
+    with:
+      target: "${{ github.event.inputs.target }}"
+    secrets: "inherit"

--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -1,0 +1,16 @@
+name: "Release Prep"
+
+on:
+  workflow_dispatch:
+   inputs:
+    target:
+      description: "The target for the release. This can be a commit sha or a branch."
+      required: false
+      default: "main"
+
+jobs:
+  release_prep:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_release_prep.yml@main"
+    with:
+      target: "${{ github.event.inputs.target }}"
+    secrets: "inherit"

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Gemfile.lock
 
 ## local rspec config
 /.rspec-local
+
+## local ruby environment
+/vendor/


### PR DESCRIPTION
Prior to this PR releasing `puppet-strings` was a manual effort.

This PR adds two new workflows:

## release_prep.yml

This workflow will update the changelog based on the version specified in the current gemspec.
It does not automatically generate the next version number. This will need to be done in a commit before this workflow is executed.

## release.yml

This workflow will build a new gem, create a GitHub release (and tag), upload the gem as a release asset and finally push the gem to rubygems.org.