### PR TITLE
(MAINT) Add matrix for acceptance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: "ci"
 on:
   push:
     branches:
-      - "maint"
+      - "main"
   pull_request:
     branches:
       - "main"
@@ -12,6 +12,19 @@ on:
   workflow_dispatch:
 
 jobs:
-  ci:
+
+  spec:
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
     secrets: "inherit"
+
+  acceptance:
+    needs: "spec"
+    strategy:
+      matrix:
+        puppet:
+          - "puppet6"
+          - "puppet7"
+    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_acceptance.yml@main"
+    secrets: "inherit"
+    with:
+      target: ${{ matrix.target }}

--- a/Gemfile
+++ b/Gemfile
@@ -14,15 +14,29 @@ else
   gem 'puppet', :require => false
 end
 
-group :test do
+group :development do
   gem 'codecov'
-  gem 'mocha'
-  gem 'puppetlabs_spec_helper'
-  gem 'serverspec'
-  gem 'simplecov-console'
-  gem 'rspec', '~> 3.1'
+
   gem 'json_spec', '~> 1.1', '>= 1.1.5'
+
   gem 'mdl'
+  gem 'mocha'
+
+  gem 'pry', require: false
+  gem 'pry-byebug', require: false
+  gem 'pry-stack_explorer', require: false 
+  gem 'puppetlabs_spec_helper'
+  
+  gem 'rake', '~> 10.0'
+  gem 'rspec', '~> 3.1'
+  gem 'rspec-its', '~> 1.0'
+  gem 'rubocop', '~> 1.6.1', require: false
+  gem 'rubocop-rspec', '~> 2.0.1', require: false
+  gem 'rubocop-performance', '~> 1.9.1', require: false
+
+  gem 'serverspec'
+  gem 'simplecov-console', require: false if ENV['COVERAGE'] == 'yes'
+  gem 'simplecov', require: false if ENV['COVERAGE'] == 'yes'
 end
 
 group :acceptance do
@@ -30,15 +44,9 @@ group :acceptance do
   gem 'net-ssh'
 end
 
-group :development do
-  gem 'github_changelog_generator'
-  gem 'pry'
-  gem 'pry-byebug'
+group :release do
+  gem 'github_changelog_generator', require: false
 end
-
-gem 'rubocop', '~> 1.6.1'
-gem 'rubocop-rspec', '~> 2.0.1'
-gem 'rubocop-performance', '~> 1.9.1'
 
 # Evaluate Gemfile.local if it exists
 if File.exists? "#{__FILE__}.local"

--- a/puppet-strings.gemspec
+++ b/puppet-strings.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.summary = 'Puppet documentation via YARD'
   s.email = 'info@puppet.com'
   s.homepage = 'https://github.com/puppetlabs/puppet-strings'
-  s.description = s.summary
   s.required_ruby_version = '>= 2.5.0'
 
   s.extra_rdoc_files = [
@@ -25,6 +24,6 @@ Gem::Specification.new do |s|
   s.files = Dir['CHANGELOG.md', 'README.md', 'LICENSE', 'lib/**/*', 'exe/**/*']
 
   s.add_runtime_dependency 'yard', '~> 0.9.5'
-  s.add_runtime_dependency 'rgen'
-  s.requirements << 'puppet, >= 5.0.0'
+  s.add_runtime_dependency 'rgen', '~> 0.9.0'
+  s.requirements << 'puppet, >= 6.0.0'
 end


### PR DESCRIPTION
This PR preps puppet-strings to use the new reusable GitHub actions. We've surface the matrix in calling workflows now and also changed the way the acceptance tests work. When calling the reusable acceptance workflow, it expects that the caller implements a rake task called acceptance with the required steps inside.