### PR TITLE
(MAINT) Remove version constraint for rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,10 +24,10 @@ group :development do
 
   gem 'pry', require: false
   gem 'pry-byebug', require: false
-  gem 'pry-stack_explorer', require: false 
+  gem 'pry-stack_explorer', require: false
   gem 'puppetlabs_spec_helper'
-  
-  gem 'rake', '~> 10.0'
+
+  gem 'rake'
   gem 'rspec', '~> 3.1'
   gem 'rspec-its', '~> 1.0'
   gem 'rubocop', '~> 1.6.1', require: false


### PR DESCRIPTION
Prior to this PR the version of rake installed with this project was vulnerable to an OS command injection attach.

The CVE ID for this is: CVE-2020-8130

This PR fixes the above by removing the version constraint and ensuring that the latest version of rake is always pulled.