### PR TITLE
(MAINT) Bump ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,7 @@ AllCops:
   - "**/Guardfile"
   - '**/*.erb'
   - 'lib/puppet-strings/yard/templates/**/*'
+  SuggestExtensions: false
 Layout/LineLength:
   Description: People have wide screens, use them.
   Max: 200

--- a/puppet-strings.gemspec
+++ b/puppet-strings.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary = 'Puppet documentation via YARD'
   s.email = 'info@puppet.com'
   s.homepage = 'https://github.com/puppetlabs/puppet-strings'
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   s.extra_rdoc_files = [
     'CHANGELOG.md',


### PR DESCRIPTION
This PR bumps the minimum required ruby version to 2.7.