### PR TITLE
(MAINT) Bump gem version

### DIFF
--- a/lib/puppet-strings/version.rb
+++ b/lib/puppet-strings/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PuppetStrings
-  VERSION = '2.9.0'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
This commit bumps the puppet-string gem version to v3.0.0.