### PR TITLE
(MAINT) Pin MDL to 0.11.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :development do
 
   gem 'json_spec', '~> 1.1', '>= 1.1.5'
 
-  gem 'mdl'
+  gem 'mdl', '~> 0.11.0'
   gem 'mocha'
 
   gem 'pry', require: false


### PR DESCRIPTION
It looks like there was a version bump of mdl this week which introduced some markdown violations.

This commit pins mdl to 0.11.0 to give us time to investigate the changes and keep ci working.