### PR TITLE
(CONT-228) Remove deprecated emit flags

### DIFF
--- a/lib/puppet/face/strings.rb
+++ b/lib/puppet/face/strings.rb
@@ -18,12 +18,6 @@ Puppet::Face.define(:strings, '0.0.1') do
     option '--markup FORMAT' do
       summary "The markup format to use for docstring text (defaults to 'markdown')."
     end
-    option '--emit-json-stdout' do
-      summary 'DEPRECATED: Print JSON representation of the documentation to stdout.'
-    end
-    option '--emit-json PATH' do
-      summary 'DEPRECATED: Write JSON representation of the documentation to the given file.'
-    end
 
     summary 'Generate documentation from files.'
     arguments '[[search_pattern] ...]'
@@ -157,12 +151,6 @@ Puppet::Face.define(:strings, '0.0.1') do
     generate_options[:backtrace] = Puppet[:trace]
     generate_options[:yard_args] = yard_args unless yard_args.empty?
     if options
-      if options[:emit_json]
-        warn "WARNING: '--emit-json PATH' is deprecated. Use '--format json --out PATH' instead."
-      end
-      if options[:emit_json_stdout]
-        warn "WARNING: '--emit-json-stdout' is deprecated. Use '--format json' instead."
-      end
       markup = options[:markup]
       generate_options[:markup] = markup if markup
       generate_options[:path] = options[:out] if options[:out]
@@ -178,15 +166,11 @@ Puppet::Face.define(:strings, '0.0.1') do
       if format
         if format.casecmp('markdown').zero?
           generate_options[:markdown] = true
-        elsif format.casecmp('json').zero? || options[:emit_json] || options[:emit_json_stdout]
+        elsif format.casecmp('json').zero?
           generate_options[:json] = true
-          generate_options[:path] ||= options[:emit_json] if options[:emit_json]
         else
           raise "Invalid format #{options[:format]}. Please select 'json' or 'markdown'."
         end
-      elsif options[:emit_json] || options[:emit_json_stdout]
-        generate_options[:json] = true
-        generate_options[:path] ||= options[:emit_json] if options[:emit_json]
       end
     end
     generate_options

--- a/spec/acceptance/generate_json_spec.rb
+++ b/spec/acceptance/generate_json_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper_acceptance'
 
-describe 'Emitting JSON' do
+describe 'Generating JSON' do
   let(:test_module_path) do
     sut_module_path(%r{Module test})
   end
@@ -50,26 +50,14 @@ describe 'Emitting JSON' do
     }
   end
 
-  [
-    { title: '--format json and STDOUT', cmd_line: '--format json' },
-    { title: '--emit-json-stdout', cmd_line: '--emit-json-stdout' },
-  ].each do |testcase|
-    it "emits JSON to stdout when using #{testcase[:title]}" do
-      output = run_shell("puppet strings generate #{testcase[:cmd_line]} \"#{test_module_path}/lib/puppet/parser/functions/function3x.rb\"").stdout.chomp
-      expect(JSON.parse(output)).to eq(expected)
-    end
+  it 'renders JSON to stdout when using --format json' do
+    output = run_shell("puppet strings generate --format json \"#{test_module_path}/lib/puppet/parser/functions/function3x.rb\"").stdout.chomp
+    expect(JSON.parse(output)).to eq(expected)
   end
 
-  [
-    { title: '--format json and --out', cmd_line: '--format json --out "TMPFILE"' },
-    { title: '--emit-json', cmd_line: '--emit-json "TMPFILE"' },
-  ].each do |testcase|
-    it "writes JSON to a file when using #{testcase[:title]}" do
-      tmpfile = File.join(remote_tmp_path, 'json_output.json')
-      cmd = "puppet strings generate #{testcase[:cmd_line].gsub('TMPFILE', tmpfile)} \"#{test_module_path}/lib/puppet/parser/functions/function3x.rb\""
-      run_shell(cmd)
-      output = JSON.parse(file(tmpfile).content)
-      expect(output).to eq(expected)
-    end
+  it 'writes JSON to a file when using --format json --out' do
+    tmpfile = File.join(remote_tmp_path, 'json_output.json')
+    run_shell("puppet strings generate --format json --out #{tmpfile} \"#{test_module_path}/lib/puppet/parser/functions/function3x.rb\"")
+    expect(JSON.parse(file(tmpfile).content)).to eq(expected)
   end
 end


### PR DESCRIPTION
Given that we are working towards a 3.0.0 release, this commit removes the two deprecated `emit_*` flags in favour of
`--format` and `--out`.