### PR TITLE
(GH-332) Ensure PuppetStrings is loaded for tasks

### DIFF
--- a/lib/puppet-strings/tasks.rb
+++ b/lib/puppet-strings/tasks.rb
@@ -3,6 +3,9 @@
 require 'rake'
 require 'rake/tasklib'
 
+# Ensure PuppetStrings is loaded.
+module PuppetStrings end
+
 # The module for Puppet Strings rake tasks.
 module PuppetStrings::Tasks
   require 'puppet-strings/tasks/generate.rb'


### PR DESCRIPTION
Prior to this PR users would receive an Undefined Constant error when attempting to generate a reference file via the provided Rake tasks.

This was caused by the compact testing style for modules added in v3.0.

In this case the parent, PuppetStrings is not properly loaded before Tasks. As a result the error above is caused.

This PR adds a new module declaration to tasks.rb that will ensure that the PuppetStrings is properly loaded.