### PR TITLE
(MAINT) Update required version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Strings processes code and YARD-style code comments to create documentation in H
 ### Requirements
 
 * Ruby 2.7.0 or newer
-* Puppet 6.0.0 or newer
+* Puppet 7.0.0 or newer
 
 ### Install Puppet Strings
 


### PR DESCRIPTION
Prior to this pr, the minimum puppet version requirement in the README was set to 6.

Given that the latest strings support is pinned to ruby 2.7, it is no longer compatible with puppet 6.

Therefore, this pr updates the minimum puppet version to 7.