### PR TITLE
Remove puppet6 reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ An example of running the acceptance tests locally with Docker:
 4. Install test items; Puppet Agent, our test module, and the puppet-strings gem built from this source code
 
     ``` bash
-    bundle exec rake 'litmus:install_agent[puppet6]'
+    bundle exec rake 'litmus:install_agent[puppet8]'
     bundle exec rake 'litmus:install_modules_from_directory[./spec/fixtures/acceptance/modules]'
     bundle exec rake litmus:install_gems
     ```


### PR DESCRIPTION
Prior to this commit the README referenced puppet6 which is no longer supported.

This commit updates an example usage of litmus to install a newer version of puppet.