### PR TITLE
(CONT-1193) - Fix bug with broken describe providers command

### DIFF
--- a/lib/puppet-strings/describe.rb
+++ b/lib/puppet-strings/describe.rb
@@ -13,17 +13,18 @@ module PuppetStrings::Describe
   def self.render(describe_types = [], list = false, _providers = false)
     document = {
       defined_types: YARD::Registry.all(:puppet_defined_type).sort_by!(&:name).map!(&:to_hash),
-      resource_types: YARD::Registry.all(:puppet_type).sort_by!(&:name).map!(&:to_hash)
+      resource_types: YARD::Registry.all(:puppet_type).sort_by!(&:name).map!(&:to_hash),
+      providers: YARD::Registry.all(:puppet_provider).sort_by!(&:name).map!(&:to_hash)
     }
 
     if list
       puts 'These are the types known to puppet:'
       document[:resource_types].each { |t| list_one_type(t) }
     else
-      document[:providers] = YARD::Registry.all(:puppet_provider).sort_by!(&:name).map!(&:to_hash)
+      document[:providers].each { |p| list_one_type(p) }
 
       type_names = {}
-      describe_types.each { |name| type_names[name] = true }
+      describe_types&.each { |name| type_names[name] = true }
 
       document[:resource_types].each do |t|
         show_one_type(t) if type_names[t[:name].to_s]

--- a/lib/puppet-strings/yard/handlers/ruby/function_handler.rb
+++ b/lib/puppet-strings/yard/handlers/ruby/function_handler.rb
@@ -322,7 +322,7 @@ class PuppetStrings::Yard::Handlers::Ruby::FunctionHandler < PuppetStrings::Yard
     end
 
     type ||= tag&.types ? tag.type : 'Any'
-    type = optional ? "Optional[#{type}]" : type
+    type = "Optional[#{type}]" if optional
 
     object.parameters << [name, to_puppet_literal(default)]
 


### PR DESCRIPTION
## Summary
This PR introduces a fix that now allows the describe providers command to work.

It also adds a null check before executing `each` on the describe_types variable as before this would result in unknown function each for Nil:Nil Class.

## Additional Context
Here is some screenshots of the bug:

Firstly, you can see it working when listing types
<img width="695" alt="image" src="https://github.com/puppetlabs/puppet-strings/assets/112936862/0a51e89d-a7ae-402f-8c84-6d7f32158068">

but, you can see the command fails to list the available providers
<img width="727" alt="image" src="https://github.com/puppetlabs/puppet-strings/assets/112936862/1da12319-6fc0-4bff-bf36-91401bf2f4c1">
You'll notice this raises an unknown function error as well as not listing the available providers in the module.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.

See both commands working with these changes:
**types**
<img width="705" alt="image" src="https://github.com/puppetlabs/puppet-strings/assets/112936862/d29a8fe5-cfb1-46bd-918e-9fa433e92ccb">

**providers**
<img width="722" alt="image" src="https://github.com/puppetlabs/puppet-strings/assets/112936862/f7a23fda-b5a9-45e2-bb4d-dd1099bf8b1f">


