### PR TITLE
Fix option tag handling with no data types

### DIFF
--- a/lib/puppet-strings/markdown/templates/classes_and_defines.erb
+++ b/lib/puppet-strings/markdown/templates/classes_and_defines.erb
@@ -70,7 +70,11 @@ Data type:<%= code_maybe_block(param[:types].join(', ')) %>
 Options:
 
 <% options_for_param(param[:name]).each do |o| -%>
+<% if o[:opt_types] -%>
 * **<%= o[:opt_name] %>** `<%= o[:opt_types][0] %>`: <%= o[:opt_text] %>
+<% else -%>
+* **<%= o[:opt_name] %>**: <%= o[:opt_text] %>
+<% end -%>
 <% end -%>
 
 <% end -%>


### PR DESCRIPTION
Do not error if no data types are provided to the option tag. Instead, generate a suitable line excluding the data type.

## Summary

When using the `@option` tag if a data type is not specified then rendering to Markdown will result in an exception being raised.  This fixes that so an appropriate documentation line is emitted instead.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
