### PR TITLE
(maint) Fix rubocop lint warnings

### DIFF
--- a/lib/puppet-strings/describe.rb
+++ b/lib/puppet-strings/describe.rb
@@ -66,7 +66,7 @@ module PuppetStrings::Describe
     targetlength = 48
     shortento = targetlength - 4
     contentstring = object[:docstring][:text]
-    end_of_line = contentstring.index("\n")  # "." gives closer results to old describeb, but breaks for '.k5login'
+    end_of_line = contentstring.index("\n") # "." gives closer results to old describeb, but breaks for '.k5login'
     contentstring = contentstring[0..end_of_line] unless end_of_line.nil?
     contentstring = "#{contentstring[0..shortento]} ..." if contentstring.length > targetlength
 

--- a/lib/puppet-strings/yard/code_objects/function.rb
+++ b/lib/puppet-strings/yard/code_objects/function.rb
@@ -8,7 +8,7 @@ class PuppetStrings::Yard::CodeObjects::Functions < PuppetStrings::Yard::CodeObj
   # @param [Symbol] type The function type to get the group for.
   # @return Returns the singleton instance of the group.
   def self.instance(type)
-    super("puppet_functions_#{type}".to_sym)
+    super(:"puppet_functions_#{type}")
   end
 
   # Gets the display name of the group.

--- a/lib/puppet-strings/yard/code_objects/provider.rb
+++ b/lib/puppet-strings/yard/code_objects/provider.rb
@@ -8,7 +8,7 @@ class PuppetStrings::Yard::CodeObjects::Providers < PuppetStrings::Yard::CodeObj
   # @param [String] type The resource type name for the provider.
   # @return Returns the singleton instance of the group.
   def self.instance(type)
-    super("puppet_providers_#{type}".to_sym)
+    super(:"puppet_providers_#{type}")
   end
 
   # Gets the display name of the group.

--- a/lib/puppet-strings/yard/code_objects/type.rb
+++ b/lib/puppet-strings/yard/code_objects/type.rb
@@ -169,7 +169,7 @@ class PuppetStrings::Yard::CodeObjects::Type < PuppetStrings::Yard::CodeObjects:
   # render-time. For now, this should re-resolve on every call.
   # may be able to memoize this
   def providers
-    providers = YARD::Registry.all("puppet_providers_#{name}".to_sym)
+    providers = YARD::Registry.all(:"puppet_providers_#{name}")
     return providers if providers.empty?
 
     providers.first.children

--- a/lib/puppet-strings/yard/util.rb
+++ b/lib/puppet-strings/yard/util.rb
@@ -35,7 +35,7 @@ module PuppetStrings::Yard::Util
   # @return [Array] Returns an array of tag hashes.
   def self.tags_to_hashes(tags)
     # Skip over the API tags that are public
-    tags.select { |t| (t.tag_name != 'api' || t.text != 'public') }.map do |t|
+    tags.select { |t| t.tag_name != 'api' || t.text != 'public' }.map do |t|
       next t.to_hash if t.respond_to?(:to_hash)
 
       tag = { tag_name: t.tag_name }


### PR DESCRIPTION
## Summary
Fix [failing nightly CI rubocop warnings](https://github.com/puppetlabs/puppet-strings/actions/runs/7080261619/job/19267899940):

```bash
➜  puppet-strings git:(maint_fix_rubocop_warnings) bundle exec rubocop --format github

::error file=lib/puppet-strings/describe.rb,line=69,col=44::Layout/ExtraSpacing: Unnecessary spacing detected.
::error file=lib/puppet-strings/yard/code_objects/function.rb,line=11,col=11::Lint/SymbolConversion: Unnecessary symbol conversion; use `:"puppet_functions_#{type}"` instead.
::error file=lib/puppet-strings/yard/code_objects/provider.rb,line=11,col=11::Lint/SymbolConversion: Unnecessary symbol conversion; use `:"puppet_providers_#{type}"` instead.
::error file=lib/puppet-strings/yard/code_objects/type.rb,line=172,col=36::Lint/SymbolConversion: Unnecessary symbol conversion; use `:"puppet_providers_#{name}"` instead.
::error file=lib/puppet-strings/yard/util.rb,line=38,col=23::Style/RedundantParentheses: Don't use parentheses around a logical expression.
➜  puppet-strings git:(maint_fix_rubocop_warnings) 
```

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
