### PR TITLE
Revert "(maint) - fix rubocop" Leading argument with delegation syntax not supported with ruby 2.7.0

### DIFF
--- a/lib/puppet-strings/yard/tags/overload_tag.rb
+++ b/lib/puppet-strings/yard/tags/overload_tag.rb
@@ -75,8 +75,8 @@ class PuppetStrings::Yard::Tags::OverloadTag < YARD::Tags::Tag
   # @param [Array] args The args passed to the method.
   # @param block The block passed to the method.
   # @return Returns what the method call on the object would return.
-  def method_missing(method_name, ...)
-    return object.send(method_name, ...) if object.respond_to? method_name
+  def method_missing(method_name, *args, &block)
+    return object.send(method_name, *args, &block) if object.respond_to? method_name
 
     super
   end


### PR DESCRIPTION
This reverts commit e6b70be9e7a4eaaf50d7eaf8d8172649b6350dcb.

## Summary
Fixes https://github.com/puppetlabs/puppet-strings/issues/375

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
