### PR TITLE
Drop outdate Ruby version checks

### DIFF
--- a/lib/puppet-strings/markdown.rb
+++ b/lib/puppet-strings/markdown.rb
@@ -76,9 +76,6 @@ module PuppetStrings::Markdown
   # @param [String] path The full path to the template file.
   # @return [ERB] Template
   def self.erb(path)
-    unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6.0')
-      # This outputs warnings in Ruby 2.6+.
-    end
     ERB.new(File.read(path), trim_mode: '-')
   end
 end

--- a/lib/puppet/face/strings.rb
+++ b/lib/puppet/face/strings.rb
@@ -144,7 +144,6 @@ Puppet::Face.define(:strings, '0.0.1') do # rubocop:disable Metrics/BlockLength
   def check_required_features
     raise "The 'yard' gem must be installed in order to use this face." unless Puppet.features.yard?
     raise "The 'rgen' gem must be installed in order to use this face." unless Puppet.features.rgen?
-    raise 'This face requires Ruby 1.9 or greater.' if RUBY_VERSION.match?(/^1\.8/)
   end
 
   # Builds the options to PuppetStrings.generate.


### PR DESCRIPTION
See individual commits for details, but they both come down to checking `RUBY_VERSION` for some old version while the gemspec declares 2.7 as the lower bound.