### PR TITLE
validate: give hint on how to regenerate outdated REFERENCE.md

### DIFF
--- a/lib/puppet-strings/tasks/validate.rb
+++ b/lib/puppet-strings/tasks/validate.rb
@@ -34,7 +34,7 @@ namespace :strings do
       existing = File.read(filename)
 
       if generated != existing
-        warn "#{filename} is outdated"
+        warn "#{filename} is outdated; to regenerate: bundle exec rake strings:generate:reference"
         exit 1
       end
     end


### PR DESCRIPTION
This is the command we use with @voxpupuli modules ([ref](https://voxpupuli.org/docs/how_to_run_tests/#referencemd-update)), not sure what the correct way is for PDK modules.