### PR TITLE
(bug) - Pin yard to < 0.9.37

### DIFF
--- a/puppet-strings.gemspec
+++ b/puppet-strings.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.files = Dir['CHANGELOG.md', 'README.md', 'LICENSE', 'lib/**/*', 'exe/**/*']
 
   s.add_runtime_dependency 'rgen', '~> 0.9'
-  s.add_runtime_dependency 'yard', '~> 0.9'
+  s.add_runtime_dependency 'yard', '~> 0.9', '< 0.9.37'
   s.requirements << 'puppet, >= 7.0.0'
 end


### PR DESCRIPTION
## Summary
Yard 0.9.37 was released, which broke our pipeline and also broke some module CI.

This commit adds a temporary pin to the gem to < 0.9.37, until we can resolve these issues.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
