### PR TITLE
Fix CI with latest yard

### DIFF
--- a/puppet-strings.gemspec
+++ b/puppet-strings.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.files = Dir['CHANGELOG.md', 'README.md', 'LICENSE', 'lib/**/*', 'exe/**/*']
 
   s.add_runtime_dependency 'rgen', '~> 0.9'
-  s.add_runtime_dependency 'yard', '~> 0.9', '< 0.9.37'
+  s.add_runtime_dependency 'yard', '~> 0.9'
   s.requirements << 'puppet, >= 7.0.0'
 end

--- a/spec/unit/puppet-strings/yard/handlers/ruby/data_type_handler_spec.rb
+++ b/spec/unit/puppet-strings/yard/handlers/ruby/data_type_handler_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper'
 require 'puppet-strings/yard'
 
+class NullLogger
+  def write(_message); end
+end
+
 describe PuppetStrings::Yard::Handlers::Ruby::DataTypeHandler, if: TEST_PUPPET_DATATYPES do
   subject(:spec_subject) do
     YARD::Parser::SourceParser.parse_string(source, :ruby)
@@ -19,7 +23,7 @@ describe PuppetStrings::Yard::Handlers::Ruby::DataTypeHandler, if: TEST_PUPPET_D
   end
 
   def suppress_yard_logging
-    YARD::Logger.instance.io = nil
+    YARD::Logger.instance.io = NullLogger.new
   end
 
   describe 'parsing source without a data type definition' do


### PR DESCRIPTION
Monkey patching libraries is a bad idea.  Latest version of yard changed
some internal details, which broke CI.

A workaround was proposed in #401 but the root cause was not addressed.

In this commit, we replace the private `io` object with an instance of a
class that provide the expected `IO#write` method instead of `nil` which
does not provide this interface in CI, so that the issue is not raised
anymore.
