### PR TITLE
List puppet as runtime dependency

### DIFF
--- a/puppet-strings.gemspec
+++ b/puppet-strings.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   ]
   s.files = Dir['CHANGELOG.md', 'README.md', 'LICENSE', 'lib/**/*', 'exe/**/*']
 
+  s.add_runtime_dependency 'puppet', '>= 7.0.0'
   s.add_runtime_dependency 'rgen', '~> 0.9'
   s.add_runtime_dependency 'yard', '~> 0.9'
-  s.requirements << 'puppet, >= 7.0.0'
 end


### PR DESCRIPTION
puppe is a runtime dependency:

```
$ git grep "require 'puppet/"
lib/puppet-strings/yard/parsers/puppet/parser.rb:require 'puppet/pops'
lib/puppet-strings/yard/parsers/puppet/statement.rb:require 'puppet/pops'
lib/puppet-strings/yard/util.rb:require 'puppet/util'
lib/puppet/application/strings.rb:require 'puppet/application/face_base'
lib/puppet/face/strings.rb:require 'puppet/face'
lib/puppet/feature/rgen.rb:require 'puppet/util/feature'
lib/puppet/feature/yard.rb:require 'puppet/util/feature'
spec/spec_helper.rb:require 'puppet/version'
```

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
