### PR TITLE
Rake task allows for a different commit message

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,8 +15,17 @@ AllCops:
   TargetRubyVersion: '3.1'
 
 # Disabled
+Layout/LineLength:
+  Max: 200
+
+Lint/RedundantCopDisableDirective:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
 Style/ClassAndModuleChildren:
   Enabled: false
 
-Layout/LineLength:
-  Max: 200
+Style/SpecialGlobalVars:
+  Enabled: false

--- a/lib/puppet-strings/tasks/gh_pages.rb
+++ b/lib/puppet-strings/tasks/gh_pages.rb
@@ -11,7 +11,9 @@ namespace :strings do
 
         Dir.chdir('doc') do
           system 'git checkout gh-pages'
+          exit 1 unless $?.success?
           system 'git pull --rebase origin gh-pages'
+          exit 1 unless $?.success?
         end
       else
         git_uri = `git config --get remote.origin.url`.strip
@@ -20,9 +22,13 @@ namespace :strings do
         Dir.mkdir('doc')
         Dir.chdir('doc') do
           system 'git init'
+          exit 1 unless $?.success?
           system "git remote add origin #{git_uri}"
+          exit 1 unless $?.success?
           system 'git pull origin gh-pages'
+          exit 1 unless $?.success?
           system 'git checkout -b gh-pages'
+          exit 1 unless $?.success?
         end
       end
     end
@@ -35,15 +41,23 @@ namespace :strings do
       end
     end
 
-    task :push do
+    # Task to push the gh-pages branch. Argument :msg_prefix is the beginning
+    # of the message and the actual commit will have "at Revision <git_sha>"
+    # appended.
+    task :push, [:msg_prefix] do |_t, args|
+      msg_prefix = args[:msg_prefix] || '[strings] Generated Documentation Update'
+
       output = `git describe --long 2>/dev/null`
       # If a project has never been tagged, fall back to latest SHA
       git_sha = output.empty? ? `git log --pretty=format:'%H' -n 1` : output
 
       Dir.chdir('doc') do
         system 'git add .'
-        system "git commit -m '[strings] Generated Documentation Update at Revision #{git_sha}'"
+        exit 1 unless $?.success?
+        system "git commit -m '#{msg_prefix} at Revision #{git_sha}'"
+        # Do not check status of commit, as it will error if there are no changes.
         system 'git push origin gh-pages -f'
+        exit 1 unless $?.success?
       end
     end
 


### PR DESCRIPTION
Without this commit, you cannot inform the rake task to push gh-pages to accept a different commit message. This is necessary in environment where commit messages have to be in specific formats.

None of the system calls were checking the exit status of their respective commands. Not stopping on error means that the rake take can fail and you and your pipelines would not know.