### PR TITLE
Remove strict puppet dependency

### DIFF
--- a/puppet-strings.gemspec
+++ b/puppet-strings.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   ]
   s.files = Dir['CHANGELOG.md', 'README.md', 'LICENSE', 'lib/**/*', 'exe/**/*']
 
-  s.add_dependency 'puppet', '>= 8.0.0'
   s.add_dependency 'rgen', '~> 0.9'
   s.add_dependency 'yard', '~> 0.9'
 end


### PR DESCRIPTION
This should no longer depend on `puppet` since there are multiple implementations that can use this. It should not materially affect any workflows since nobody uses `gem install puppet-strings` to install Puppet!
