### PR TITLE
Expand delimiters if code contains backticks

### DIFF
--- a/lib/puppet-strings/markdown/helpers.rb
+++ b/lib/puppet-strings/markdown/helpers.rb
@@ -4,18 +4,27 @@
 module PuppetStrings::Markdown::Helpers
   # Formats code as either inline or a block.
   #
-  # Note that this does not do any escaping even if the code contains ` or ```.
+  # Delimiters are expanded if the code contains the default delimiter.
   #
   # @param [String] code The code to format.
   # @param [Symbol] type The type of the code, e.g. :text, :puppet, or :ruby.
-  # @param [String] block_prefix String to insert before if it’s a block.
-  # @param [String] inline_prefix String to insert before if it’s inline.
+  # @param [String] block_prefix String to insert before if it's a block.
+  # @param [String] inline_prefix String to insert before if it's inline.
   # @returns [String] Markdown
   def code_maybe_block(code, type: :puppet, block_prefix: "\n\n", inline_prefix: ' ')
-    if code.to_s.include?("\n")
-      "#{block_prefix}```#{type}\n#{code}\n```"
+    code_s = code.to_s
+    if code_s.include?("\n") || code_s.length > 70
+      # Delimiter must be one backtick longer than the longest series of backticks
+      #   beginning a line, minimum 3 (with some spaces allowed).
+      delim = (code_s.scan(/^ {0,3}``(`+)\s*$/) << '').flatten.max_by(&:length) + '```'
+      "#{block_prefix}#{delim}#{type}\n#{code_s}\n#{delim}"
     else
-      "#{inline_prefix}`#{code}`"
+      # Delimeter must be one backtick longer than the longest series of backticks
+      #   in the string.
+      delim = code_s.scan(/`*/).max_by(&:length) + '`'
+      # Padding required if string starts or ends with a backtick
+      pad = (code_s[0] == '`' || code_s[-1] == '`') ? ' ' : ''
+      "#{inline_prefix}#{delim}#{pad}#{code_s}#{pad}#{delim}"
     end
   end
 end

--- a/lib/puppet-strings/markdown/helpers.rb
+++ b/lib/puppet-strings/markdown/helpers.rb
@@ -10,10 +10,11 @@ module PuppetStrings::Markdown::Helpers
   # @param [Symbol] type The type of the code, e.g. :text, :puppet, or :ruby.
   # @param [String] block_prefix String to insert before if it's a block.
   # @param [String] inline_prefix String to insert before if it's inline.
+  # @param [Symbol] whether to force a format (:inline, :block) or determine by content (:none).
   # @returns [String] Markdown
-  def code_maybe_block(code, type: :puppet, block_prefix: "\n\n", inline_prefix: ' ')
+  def code_maybe_block(code, type: :puppet, block_prefix: "\n\n", inline_prefix: ' ', force: :none)
     code_s = code.to_s
-    if code_s.include?("\n") || code_s.length > 70
+    if (code_s.include?("\n") || code_s.length > 70 || force == :block) && force != :inline
       # Delimiter must be one backtick longer than the longest series of backticks
       #   beginning a line, minimum 3 (with some spaces allowed).
       delim = (code_s.scan(/^ {0,3}``(`+)\s*$/) << '').flatten.max_by(&:length) + '```'

--- a/lib/puppet-strings/markdown/templates/classes_and_defines.erb
+++ b/lib/puppet-strings/markdown/templates/classes_and_defines.erb
@@ -59,7 +59,7 @@ The following parameters are available in the `<%= name %>` <%= @type %>:
 ##### <a name="<%= param[:link] %>"></a>`<%= param[:name] %>`
 
 <% if param[:types] -%>
-Data type:<%= param[:types].map{|val| code_maybe_block(val, force: :inline)}.join(',') %>
+Data type:<%= code_maybe_block(param[:types].join(', ')) %>
 
 <% end -%>
 <%= param[:text] %>

--- a/lib/puppet-strings/markdown/templates/classes_and_defines.erb
+++ b/lib/puppet-strings/markdown/templates/classes_and_defines.erb
@@ -42,9 +42,7 @@
 <% examples.each do |eg| -%>
 ##### <%= eg[:name] %>
 
-```puppet
-<%= eg[:text] %>
-```
+<%= code_maybe_block(eg[:text], block_prefix: '', force: :block) %>
 
 <% end -%>
 <% end -%>
@@ -61,7 +59,7 @@ The following parameters are available in the `<%= name %>` <%= @type %>:
 ##### <a name="<%= param[:link] %>"></a>`<%= param[:name] %>`
 
 <% if param[:types] -%>
-Data type:<%= code_maybe_block(param[:types].join(', ')) %>
+Data type:<%= param[:types].map{|val| code_maybe_block(val, force: :inline)}.join(',') %>
 
 <% end -%>
 <%= param[:text] %>
@@ -71,7 +69,7 @@ Options:
 
 <% options_for_param(param[:name]).each do |o| -%>
 <% if o[:opt_types] -%>
-* **<%= o[:opt_name] %>** `<%= o[:opt_types][0] %>`: <%= o[:opt_text] %>
+* **<%= o[:opt_name] %>**<%= code_maybe_block(o[:opt_types][0], force: :inline) %>: <%= o[:opt_text] %>
 <% else -%>
 * **<%= o[:opt_name] %>**: <%= o[:opt_text] %>
 <% end -%>

--- a/lib/puppet-strings/markdown/templates/data_type.erb
+++ b/lib/puppet-strings/markdown/templates/data_type.erb
@@ -42,9 +42,7 @@
 <% examples.each do |eg| -%>
 ##### <%= eg[:name] %>
 
-```puppet
-<%= eg[:text] %>
-```
+<%= code_maybe_block(eg[:text], block_prefix: '', force: :block) %>
 
 <% end -%>
 <% end -%>
@@ -74,7 +72,7 @@ Data type:<%= code_maybe_block(param[:types].join(', ')) %>
 Options:
 
 <% options_for_param(param[:name]).each do |o| -%>
-* **<%= o[:opt_name] %>** `<%= o[:opt_types][0] %>`: <%= o[:opt_text] %>
+* **<%= o[:opt_name] %>**<%= code_maybe_block(o[:opt_types][0], force: :inline) %>: <%= o[:opt_text] %>
 <% end -%>
 
 <% end -%>

--- a/lib/puppet-strings/markdown/templates/data_type_function.erb
+++ b/lib/puppet-strings/markdown/templates/data_type_function.erb
@@ -1,6 +1,6 @@
 ### <a name="<%= link %>"></a>`<%= name %>`
 
-#### `<%= signature %>`
+####<%= code_maybe_block(signature, force: :inline) %>
 
 <% if text -%>
 <%= text %>
@@ -17,7 +17,7 @@
 
 <% end -%>
 <% if return_type -%>
-Returns: `<%= return_type %>`<% if return_val %> <%= return_val %><% end %>
+Returns:<%= code_maybe_block(return_type, force: :inline) %><% if return_val %> <%= return_val %><% end %>
 
 <% end -%>
 <% if raises -%>
@@ -33,9 +33,7 @@ Raises:
 <% examples.each do |eg| -%>
 ###### <%= eg[:name] %>
 
-```puppet
-<%= eg[:text] %>
-```
+<%= code_maybe_block(eg[:text], block_prefix: '', force: :block) %>
 
 <% end -%>
 <% end -%>
@@ -51,7 +49,7 @@ Data type:<%= code_maybe_block(param[:types][0]) %>
 Options:
 
 <% options_for_param(param[:name]).each do |o| -%>
-* **<%= o[:opt_name] %>** `<%= o[:opt_types][0] %>`: <%= o[:opt_text] %>
+* **<%= o[:opt_name] %>**<%= code_maybe_block(o[:opt_types][0], force: :inline) %>: <%= o[:opt_text] %>
 <% end -%>
 
 <% end -%>

--- a/lib/puppet-strings/markdown/templates/function.erb
+++ b/lib/puppet-strings/markdown/templates/function.erb
@@ -30,14 +30,12 @@ Type: <%= type %>
 <% examples.each do |eg| -%>
 ##### <%= eg[:name] %>
 
-```puppet
-<%= eg[:text] %>
-```
+<%= code_maybe_block(eg[:text], block_prefix: '', force: :block) %>
 
 <% end -%>
 <% end -%>
 <% signatures.each do |sig| -%>
-#### `<%= sig.signature %>`
+####<%= code_maybe_block(sig.signature, force: :inline) %>
 
 <% if sig.text -%>
 <%= sig.text %>
@@ -54,7 +52,7 @@ Type: <%= type %>
 
 <% end -%>
 <% if sig.return_type -%>
-Returns: `<%= sig.return_type %>`<% if sig.return_val %> <%= sig.return_val %><% end %>
+Returns:<%= code_maybe_block(sig.return_type, force: :inline) %><% if sig.return_val %> <%= sig.return_val %><% end %>
 
 <% end -%>
 <% if raises -%>
@@ -71,9 +69,7 @@ Raises:
 <% sig.examples.each do |eg| -%>
 ###### <%= eg[:name] %>
 
-```puppet
-<%= eg[:text] %>
-```
+<%= code_maybe_block(eg[:text], block_prefix: '', force: :block) %>
 
 <% end -%>
 <% end -%>
@@ -89,7 +85,7 @@ Data type:<%= code_maybe_block(param[:types][0]) %>
 Options:
 
 <% sig.options_for_param(param[:name]).each do |o| -%>
-* **<%= o[:opt_name] %>** `<%= o[:opt_types][0] %>`: <%= o[:opt_text] %>
+* **<%= o[:opt_name] %>**<%= code_maybe_block(o[:opt_types][0], force: :inline) %>: <%= o[:opt_text] %>
 <% end -%>
 
 <% end -%>

--- a/lib/puppet-strings/markdown/templates/puppet_task.erb
+++ b/lib/puppet-strings/markdown/templates/puppet_task.erb
@@ -19,7 +19,7 @@
 ##### `<%= param[:name] %>`
 
 <% if param[:types] -%>
-Data type:<%= code_maybe_block(param[:types].join(', ')) %>
+Valid values:<%= param[:types].map{|type| code_maybe_block(type, force: :inline)}.join(',') %>
 
 <% end -%>
 <%= param[:text] %>

--- a/lib/puppet-strings/markdown/templates/puppet_task.erb
+++ b/lib/puppet-strings/markdown/templates/puppet_task.erb
@@ -19,7 +19,7 @@
 ##### `<%= param[:name] %>`
 
 <% if param[:types] -%>
-Valid values:<%= param[:types].map{|type| code_maybe_block(type, force: :inline)}.join(',') %>
+Data type:<%= code_maybe_block(param[:types].join(', ')) %>
 
 <% end -%>
 <%= param[:text] %>

--- a/lib/puppet-strings/markdown/templates/resource_type.erb
+++ b/lib/puppet-strings/markdown/templates/resource_type.erb
@@ -42,9 +42,7 @@
 <% examples.each do |eg| -%>
 ##### <%= eg[:name] %>
 
-```puppet
-<%= eg[:text] %>
-```
+<%= code_maybe_block(eg[:text], block_prefix: '', force: :block) %>
 
 <% end -%>
 <% end -%>
@@ -57,7 +55,7 @@ The following properties are available in the `<%= name %>` <%= @type %>.
 ##### `<%= prop[:name] %>`
 
 <% if prop[:values] -%>
-Valid values: `<%= prop[:values].join('`, `') %>`
+Valid values:<%= prop[:values].map{|val| code_maybe_block(val, force: :inline)}.join(',') %>
 
 <% end -%>
 <% if prop[:isnamevar] -%>
@@ -69,7 +67,7 @@ Aliases: `<%= prop[:aliases].to_s.delete('{').delete('}') %>`
 
 <% end -%>
 <% if prop[:data_type] -%>
-Data type: `<%= prop[:data_type] %>`<%= "\n_\*this data type contains a regex that may not be accurately reflected in generated documentation_" if regex_in_data_type?(prop[:data_type]) %>
+Data type:<%= code_maybe_block(prop[:data_type]) %>
 
 <% end -%>
 <%= prop[:description] %>
@@ -78,7 +76,7 @@ Data type: `<%= prop[:data_type] %>`<%= "\n_\*this data type contains a regex th
 Options:
 
 <% options_for_param(prop[:name]).each do |o| -%>
-* **<%= o[:opt_name] %>** `<%= o[:opt_types][0] %>`: <%= o[:opt_text] %>
+* **<%= o[:opt_name] %>**<%= code_maybe_block(o[:opt_types][0], force: :inline) %>: <%= o[:opt_text] %>
 <% end -%>
 
 <% end -%>
@@ -109,7 +107,7 @@ The following parameters are available in the `<%= name %>` <%= @type %>.
 ##### <a name="<%= param[:link] %>"></a>`<%= param[:name] %>`
 
 <% if param[:values] -%>
-Valid values: `<%= param[:values].join('`, `') %>`
+Valid values:<%= param[:values].map{|val| code_maybe_block(val, force: :inline)}.join(',') %>
 
 <% end -%>
 <% if param[:isnamevar] -%>
@@ -121,7 +119,7 @@ Aliases: `<%= param[:aliases].to_s.delete('{').delete('}') %>`
 
 <% end -%>
 <% if param[:data_type] -%>
-Data type: `<%= param[:data_type] %>`<%= "\n_\*this data type contains a regex that may not be accurately reflected in generated documentation_" if regex_in_data_type?(param[:data_type]) %>
+Data type:<%= code_maybe_block(param[:data_type]) %>
 
 <% end -%>
 <% if param[:description] -%>
@@ -132,7 +130,7 @@ Data type: `<%= param[:data_type] %>`<%= "\n_\*this data type contains a regex t
 Options:
 
 <% options_for_param(param[:name]).each do |o| -%>
-* **<%= o[:opt_name] %>** `<%= o[:opt_types][0] %>`: <%= o[:opt_text] %>
+* **<%= o[:opt_name] %>**<%= code_maybe_block(o[:opt_types][0], force: :inline) %>: <%= o[:opt_text] %>
 <% end -%>
 
 <% end -%>
@@ -145,7 +143,7 @@ Options:
 
 <% end -%>
 <% if param[:default] -%>
-Default value: `<%= param[:default] %>`
+Default value:<%= code_maybe_block(param[:default]) %>
 
 <% end -%>
 <% if param[:required_features] -%>

--- a/lib/puppet-strings/markdown/templates/resource_type.erb
+++ b/lib/puppet-strings/markdown/templates/resource_type.erb
@@ -55,7 +55,7 @@ The following properties are available in the `<%= name %>` <%= @type %>.
 ##### `<%= prop[:name] %>`
 
 <% if prop[:values] -%>
-Valid values:<%= prop[:values].map{|val| code_maybe_block(val, force: :inline)}.join(',') %>
+Valid values: `<%= prop[:values].join('`, `') %>`
 
 <% end -%>
 <% if prop[:isnamevar] -%>
@@ -107,7 +107,7 @@ The following parameters are available in the `<%= name %>` <%= @type %>.
 ##### <a name="<%= param[:link] %>"></a>`<%= param[:name] %>`
 
 <% if param[:values] -%>
-Valid values:<%= param[:values].map{|val| code_maybe_block(val, force: :inline)}.join(',') %>
+Valid values: `<%= param[:values].join('`, `') %>`
 
 <% end -%>
 <% if param[:isnamevar] -%>


### PR DESCRIPTION
## Summary
Generated markdown was incorrect when an inline code block contained backticks.

## Additional Context
Markdown inline code or fenced code blocks do not allow for the closing delimiter to be escaped.  Instead, the length of the delimiter can be changed to accommodate any reasonable content.

I have also made the stylistic change of making single-line code strings longer than 70 characters into fenced blocks, so that the code displays in its original horizontal format, instead of being wrapped by the browser.

### Examples
#### 1. Backtick in data type:
The original case that prompted me to do this was a Pattern type that included a backtick in a character class.

```puppet
type My_module::My_type = Pattern[/\A[- \w~`<>.,?\/"#]+\z/]
```

Which produced this:

```markdown
Alias of `Pattern[/\A[- \w~`<>.,?\/"#]+\z/]`
```

And looks like this:

> Alias of `Pattern[/\A[- \w~`<>.,?\/"#]+\z/]`

After the change, it produces this:

```markdown
Alias of ``Pattern[/\A[/\A[- \w~`<>.,?\/"#]+\z/]``
```

Which looks like this:

> Alias of ``Pattern[/\A[/\A[- \w~`<>.,?\/"#]+\z/]``

#### 2. Fenced code in example:
This is the case I contrived to test the change as it applies to fenced blocks.

```puppet
# @example Basic usage
#   $md_content = @(EndMD)
#     # Documentation
#     We're documenting something
#
#     ## Code
#     Here's a code example:
#
#     ```javascript
#     let x = 10;
#     ```
#
#     ## More Info
#     Lorem ipsum whatever.
#     | EndMD
#
#   my_module::markdown_file { '/srv/docs_md/something.md':
#     ensure  => 'file',
#     content => $md_content,
#   }
```

Which produced:

````markdown
#### Examples

##### Basic usage

```puppet
$md_content = @(EndMD)
  # Documentation

  We're documenting something

  ## Code

  Here's a code example:

  ```javascript
  let x = 10;
  ```

  ## More Info

  Lorem ipsum whatever.
  | EndMD

my_module::markdown_file { '/srv/docs_md/something.md':
  ensure  => 'file',
  content => $md_content,
}
```

#### Parameters
…
````

And is broken like this:

> #### Examples
> 
> ##### Basic usage
> 
> ```puppet
> $md_content = @(EndMD)
>   # Documentation
> 
>   We're documenting something
> 
>   ## Code
> 
>   Here's a code example:
> 
>   ```javascript
>   let x = 10;
>   ```
> 
>   ## More Info
> 
>   Lorem ipsum whatever.
>   | EndMD
> 
> my_module::markdown_file { '/srv/docs_md/something.md':
>   ensure  => 'file',
>   content => $md_content,
> }
> ```
> 
> #### Parameters
> …

After the change we get:

`````markdown
#### Examples

##### Basic usage

````puppet
$md_content = @(EndMD)
  # Documentation

  We're documenting something

  ## Code

  Here's a code example:

  ```javascript
  let x = 10;
  ```

  ## More Info

  Lorem ipsum whatever.
  | EndMD

my_module::markdown_file { '/srv/docs_md/something.md':
  ensure  => 'file',
  content => $md_content,
}
````

#### Parameters
…
`````

Which displays correctly:

> #### Examples
> 
> ##### Basic usage
> 
> ````puppet
> $md_content = @(EndMD)
>   # Documentation
> 
>   We're documenting something
> 
>   ## Code
> 
>   Here's a code example:
> 
>   ```javascript
>   let x = 10;
>   ```
> 
>   ## More Info
> 
>   Lorem ipsum whatever.
>   | EndMD
> 
> my_module::markdown_file { '/srv/docs_md/something.md':
>   ensure  => 'file',
>   content => $md_content,
> }
> ````
> 
> #### Parameters
> …

#### 3. Long value:
To demonstrate the advantage of using block style for long values, I'll borrow a data type from the `stdlib` module.

Old:

```markdown
Alias of `Enum['ACL', 'BASELINE-CONTROL', 'BIND', 'CHECKIN', 'CHECKOUT', 'CONNECT', 'COPY', 'DELETE', 'GET', 'HEAD', 'LABEL', 'LINK', 'LOCK', 'MERGE', 'MKACTIVITY', 'MKCALENDAR', 'MKCOL', 'MKREDIRECTREF', 'MKWORKSPACE', 'MOVE', 'OPTIONS', 'ORDERPATCH', 'PATCH', 'POST', 'PRI', 'PROPFIND', 'PROPPATCH', 'PUT', 'REBIND', 'REPORT', 'SEARCH', 'TRACE', 'UNBIND', 'UNCHECKOUT', 'UNLINK', 'UNLOCK', 'UPDATE', 'UPDATEREDIRECTREF', 'VERSION-CONTROL']`
```

Which renders:

> Alias of `Enum['ACL', 'BASELINE-CONTROL', 'BIND', 'CHECKIN', 'CHECKOUT', 'CONNECT', 'COPY', 'DELETE', 'GET', 'HEAD', 'LABEL', 'LINK', 'LOCK', 'MERGE', 'MKACTIVITY', 'MKCALENDAR', 'MKCOL', 'MKREDIRECTREF', 'MKWORKSPACE', 'MOVE', 'OPTIONS', 'ORDERPATCH', 'PATCH', 'POST', 'PRI', 'PROPFIND', 'PROPPATCH', 'PUT', 'REBIND', 'REPORT', 'SEARCH', 'TRACE', 'UNBIND', 'UNCHECKOUT', 'UNLINK', 'UNLOCK', 'UPDATE', 'UPDATEREDIRECTREF', 'VERSION-CONTROL']`

New:

````markdown
Alias of

```puppet
Enum['ACL', 'BASELINE-CONTROL', 'BIND', 'CHECKIN', 'CHECKOUT', 'CONNECT', 'COPY', 'DELETE', 'GET', 'HEAD', 'LABEL', 'LINK', 'LOCK', 'MERGE', 'MKACTIVITY', 'MKCALENDAR', 'MKCOL', 'MKREDIRECTREF', 'MKWORKSPACE', 'MOVE', 'OPTIONS', 'ORDERPATCH', 'PATCH', 'POST', 'PRI', 'PROPFIND', 'PROPPATCH', 'PUT', 'REBIND', 'REPORT', 'SEARCH', 'TRACE', 'UNBIND', 'UNCHECKOUT', 'UNLINK', 'UNLOCK', 'UPDATE', 'UPDATEREDIRECTREF', 'VERSION-CONTROL']
```
````

And that looks like this, which I think is more code-like and a little easier to read, even though the whole thing can't be seen at once:

> Alias of
> 
> ```puppet
> Enum['ACL', 'BASELINE-CONTROL', 'BIND', 'CHECKIN', 'CHECKOUT', 'CONNECT', 'COPY', 'DELETE', 'GET', 'HEAD', 'LABEL', 'LINK', 'LOCK', 'MERGE', 'MKACTIVITY', 'MKCALENDAR', 'MKCOL', 'MKREDIRECTREF', 'MKWORKSPACE', 'MOVE', 'OPTIONS', 'ORDERPATCH', 'PATCH', 'POST', 'PRI', 'PROPFIND', 'PROPPATCH', 'PUT', 'REBIND', 'REPORT', 'SEARCH', 'TRACE', 'UNBIND', 'UNCHECKOUT', 'UNLINK', 'UNLOCK', 'UPDATE', 'UPDATEREDIRECTREF', 'VERSION-CONTROL']
> ```

## Related Issues (if any)
I did not find anything related.  The original code comments do mention the omission.

## Tests
I did not find any test that directly tests the `code_maybe_block()` function, or I would have added a couple of test cases.  Additionally, the the test that might apply is very simplistic, and additions that would properly test this function and change would, I think, substantially change the existing test in ways I don't know if they would be acceptable.
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
In addition to testing with my own modules, I ran the puppetlabs/stdlib and puppetlabs/apache modules through this.  When I `diff`ed the results, the only changes were as expected.
